### PR TITLE
curl -> wget

### DIFF
--- a/docker-compose/examples/pdb70/setup.sh
+++ b/docker-compose/examples/pdb70/setup.sh
@@ -4,7 +4,7 @@ NAME=PDB70
 VERSION=latest
 
 mkdir -p databases
-curl "http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/pdb70_from_mmcif_${VERSION}.tar.gz" \
+wget "http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/pdb70_from_mmcif_${VERSION}.tar.gz" -O - \
     | tar -xOzf - pdb70_a3m.ffdata | tr -d '\000'| awk -v outfile="databases/pdb70_${VERSION}_msa" -f "${SELF}/pdb70.awk"
 awk 'BEGIN { printf("%c%c%c%c",11,0,0,0); exit; }' > "databases/pdb70_${VERSION}_msa.dbtype"
 


### PR DESCRIPTION
I have no idea why, but `../examples/pdb70/setup.sh` from the docker-compose readme fails when trying `curl`, but works when using `wget` (with an additional arg to print to stdout).