### PR TITLE
fix: rank undefined issue

### DIFF
--- a/frontend/SankeyDiagram.vue
+++ b/frontend/SankeyDiagram.vue
@@ -132,12 +132,16 @@ export default {
 					if (node.rank !== "clade") {
 						let lastLineageNode = currentLineage[currentLineage.length - 1];
 						if (lastLineageNode) {
-
 							let currentRank = rankHierarchyFull[node.rank] ?? Infinity;
 							let lastRank = rankHierarchyFull[lastLineageNode.rank] ?? Infinity;
-								while (lastLineageNode && currentRank <= lastRank) {
+							
+							while (lastLineageNode && currentRank <= lastRank) {
 								const poppedNode = currentLineage.pop();
 								lastLineageNode = currentLineage[currentLineage.length - 1];
+
+								if (!lastLineageNode) {
+									break; // Exit the loop if no more nodes in the lineage
+								}
 
 								currentRank = rankHierarchyFull[node.rank] ?? Infinity;
 								lastRank = rankHierarchyFull[lastLineageNode.rank] ?? Infinity;


### PR DESCRIPTION
Cause of error:
- There was an issue in the case where there is more than one superkingdoms. In the process of backtracking the list to find the lineage of the second superkingdom, it would produce an undefined object because there superkingdom is the highest rank in the sankey.

Fix:
- Added a check for undefined or null.

Note to reviewer:
- I only checked that the sankey is drawn and rendered correctly with the taxonomy report file. Needs check to make sure selecting the nodes filters hits correctly.