### PR TITLE
Addition of show/hide toggle and fixes to hits filtering feature

### DIFF
--- a/frontend/ResultView.vue
+++ b/frontend/ResultView.vue
@@ -98,8 +98,8 @@
                         </h2>
 
                         <!-- Button to toggle Sankey Diagram visibility -->
-                        <v-btn @click="isSankeyVisible = !isSankeyVisible" class="ml-auto mr-2" large>
-                            {{ isSankeyVisible ? 'Hide Sankey' : 'Show Sankey' }}
+                        <v-btn @click="toggleSankeyVisibility(entry.db)" class="ml-auto mr-2" large>
+                            {{ isSankeyVisible[entry.db] ? 'Hide Sankey' : 'Show Sankey' }}
                         </v-btn>
                         
                         <v-btn-toggle mandatory v-model="tableMode" >
@@ -112,7 +112,7 @@
                             </v-btn>
                         </v-btn-toggle>
                     </v-flex>
-                    <v-flex v-if="isSankeyVisible && entry.taxonomyreport" class="mb-2">
+                    <v-flex v-if="isSankeyVisible[entry.db] && entry.taxonomyreport" class="mb-2">
                         <SankeyDiagram :rawData="entry.taxonomyreport" :currentSelectedNodeId="selectedTaxId" @selectTaxon="handleSankeySelect"></SankeyDiagram>
                     </v-flex>
                     <table class="v-table result-table" style="position:relativ; margin-bottom: 3em;">
@@ -281,7 +281,7 @@ export default {
             activeTarget: null,
             alnBoxOffset: 0,
             selectedDatabases: 0,
-            isSankeyVisible: false,
+            isSankeyVisible: {}, // Track visibility for each entry.db
             selectedTaxId: null,
             filteredHitsTaxIds: [],
             tableMode: 0,
@@ -375,6 +375,10 @@ export default {
                 this.menuItems = items;
                 this.menuActivator.click(event);
             }
+        },
+        toggleSankeyVisibility(db) {
+            // Toggle visibility for the specific entry.db
+            this.$set(this.isSankeyVisible, db, !this.isSankeyVisible[db]);
         },
         handleSankeySelect({ nodeId, descendantIds }) {
             this.selectedTaxId = nodeId;

--- a/frontend/ResultView.vue
+++ b/frontend/ResultView.vue
@@ -113,7 +113,7 @@
                         </v-btn-toggle>
                     </v-flex>
                     <v-flex v-if="isSankeyVisible[entry.db] && entry.taxonomyreport" class="mb-2">
-                        <SankeyDiagram :rawData="entry.taxonomyreport" :currentSelectedNodeId="selectedTaxId" @selectTaxon="handleSankeySelect"></SankeyDiagram>
+                        <SankeyDiagram :rawData="entry.taxonomyreport" :db="entry.db" :currentSelectedNodeId="selectedTaxId" :currentSelectedDb="filteredDb" @selectTaxon="handleSankeySelect"></SankeyDiagram>
                     </v-flex>
                     <table class="v-table result-table" style="position:relativ; margin-bottom: 3em;">
                         <colgroup>
@@ -185,7 +185,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <template v-for="(group, groupidx) in filteredAlignments(entry.alignments)" >
+                            <template v-for="(group, groupidx) in filteredAlignments(entry.alignments, entry.db)" >
                                 <tr v-for="(item, index) in group" :class="['hit', { 'active' : item.active }]">
                                 <template v-if="index == 0 && isComplex">
                                 <td class="thin" data-label="Query TM-score" :rowspan="group.length">{{ group[0].complexqtm.toFixed(2) }}</td>
@@ -282,6 +282,7 @@ export default {
             alnBoxOffset: 0,
             selectedDatabases: 0,
             isSankeyVisible: {}, // Track visibility for each entry.db
+            filteredDb: null,
             selectedTaxId: null,
             filteredHitsTaxIds: [],
             tableMode: 0,
@@ -380,18 +381,24 @@ export default {
             // Toggle visibility for the specific entry.db
             this.$set(this.isSankeyVisible, db, !this.isSankeyVisible[db]);
         },
-        handleSankeySelect({ nodeId, descendantIds }) {
+        handleSankeySelect({ nodeId, descendantIds, db }) {
             this.selectedTaxId = nodeId;
             this.filteredHitsTaxIds = descendantIds ? descendantIds.map(Number) : null; 
+            this.filteredDb = db;
         },
-        filteredAlignments(alignments) {
+        filteredAlignments(alignments, db) {
             // Convert alignments to an array if it is an object
             if (alignments && !Array.isArray(alignments)) {
                 alignments = Object.values(alignments);
             }
-
+            
             if (!Array.isArray(alignments)) {
                 return []; // Return an empty array if conversion fails
+            }
+
+            if (db !== this.filteredDb) {
+                // Reset filteredHitsTaxIds if db changes
+                return alignments;
             }
 
             if (!this.filteredHitsTaxIds || this.filteredHitsTaxIds.length === 0) {

--- a/frontend/ResultView.vue
+++ b/frontend/ResultView.vue
@@ -113,7 +113,7 @@
                         </v-btn-toggle>
                     </v-flex>
                     <v-flex v-if="entry.hasTaxonomy && isSankeyVisible[entry.db]" class="mb-2">
-                        <SankeyDiagram :rawData="entry.taxonomyreport" :db="entry.db" :currentSelectedNodeId="selectedTaxId" :currentSelectedDb="filteredDb" @selectTaxon="handleSankeySelect"></SankeyDiagram>
+                        <SankeyDiagram :rawData="entry.taxonomyreport" :db="entry.db" :currentSelectedNodeId="selectedTaxId" :currentSelectedDb="selectedDb" @selectTaxon="handleSankeySelect"></SankeyDiagram>
                     </v-flex>
                     <table class="v-table result-table" style="position:relativ; margin-bottom: 3em;">
                         <colgroup>
@@ -282,7 +282,7 @@ export default {
             alnBoxOffset: 0,
             selectedDatabases: 0,
             isSankeyVisible: {}, // Track visibility for each entry.db
-            filteredDb: null,
+            selectedDb: null,
             selectedTaxId: null,
             filteredHitsTaxIds: [],
             tableMode: 0,
@@ -384,7 +384,7 @@ export default {
         handleSankeySelect({ nodeId, descendantIds, db }) {
             this.selectedTaxId = nodeId;
             this.filteredHitsTaxIds = descendantIds ? descendantIds.map(Number) : null; 
-            this.filteredDb = db;
+            this.selectedDb = db;
         },
         filteredAlignments(alignments, db) {
             // Convert alignments to an array if it is an object
@@ -396,7 +396,7 @@ export default {
                 return []; // Return an empty array if conversion fails
             }
 
-            if (db !== this.filteredDb) {
+            if (db !== this.selectedDb) {
                 // Reset filteredHitsTaxIds if db changes
                 return alignments;
             }

--- a/frontend/ResultView.vue
+++ b/frontend/ResultView.vue
@@ -93,13 +93,13 @@
                     </v-tabs>
                     <div v-for="(entry, index) in hits.results" :key="entry.db" v-if="selectedDatabases == 0 || (index + 1) == selectedDatabases">
                     <v-flex class="d-flex" :style="{ 'flex-direction' : $vuetify.breakpoint.xsOnly ? 'column' : null, 'align-items': 'center' }">
-                        <h2 style="margin-top: 0.5em; margin-bottom: 1em; display: inline-block;">
+                        <h2 style="margin-top: 0.5em; margin-bottom: 1em; display: inline-block;" class="mr-auto">
                             <span style="text-transform: uppercase;">{{ entry.db }}</span> <small>{{ entry.alignments ? Object.values(entry.alignments).length : 0 }} hits</small>
                         </h2>
 
                         <!-- Button to toggle Sankey Diagram visibility -->
-                        <v-btn @click="toggleSankeyVisibility(entry.db)" class="ml-auto mr-2" large>
-                            {{ isSankeyVisible[entry.db] ? 'Hide Sankey' : 'Show Sankey' }}
+                        <v-btn v-if="entry.hasTaxonomy" @click="toggleSankeyVisibility(entry.db)" class="mr-2" large>
+                            {{ isSankeyVisible[entry.db] ? 'Hide Taxonomy' : 'Show Taxonomy' }}
                         </v-btn>
                         
                         <v-btn-toggle mandatory v-model="tableMode" >
@@ -112,7 +112,7 @@
                             </v-btn>
                         </v-btn-toggle>
                     </v-flex>
-                    <v-flex v-if="isSankeyVisible[entry.db] && entry.taxonomyreport" class="mb-2">
+                    <v-flex v-if="entry.hasTaxonomy && isSankeyVisible[entry.db]" class="mb-2">
                         <SankeyDiagram :rawData="entry.taxonomyreport" :db="entry.db" :currentSelectedNodeId="selectedTaxId" :currentSelectedDb="filteredDb" @selectTaxon="handleSankeySelect"></SankeyDiagram>
                     </v-flex>
                     <table class="v-table result-table" style="position:relativ; margin-bottom: 3em;">

--- a/frontend/SankeyDiagram.vue
+++ b/frontend/SankeyDiagram.vue
@@ -20,6 +20,14 @@ export default {
 			type: String,
 			default: null,
 		},
+		db: {
+			type: String,
+			required: true,
+		},
+		// currentSelectedDb: {
+		// 	type: String,
+		// 	default: null,
+		// }
 	},
     data: () => ({
 		currentSelectedNode: null, // Track the currently selected node
@@ -66,6 +74,13 @@ export default {
 				});
 			},
 		},
+		// currentSelectedNodeId(newValue) {
+		// 	if (newValue) {
+		// 		if (newValue !== this.db) {
+		// 			this.currentSelectedNode = null;
+		// 		}
+		// 	}
+		// }
     },
     methods: {
 		// Function for processing/parsing data
@@ -426,7 +441,7 @@ export default {
 					// If the same node is clicked again, deselect it
 					if (this.currentSelectedNode && this.currentSelectedNode.id === d.id) {
 						this.currentSelectedNode = null;
-						this.$emit("selectTaxon", { nodeId: null, descendantIds: null }); // Emit an empty array to show all IDs
+						this.$emit("selectTaxon", { nodeId: null, descendantIds: null, db: this.db }); // Emit an empty array to show all IDs
 						return;
 					}
 
@@ -453,7 +468,7 @@ export default {
         			this.currentSelectedNode = d;
 
 					// Emit the IDs array
-					this.$emit("selectTaxon", { nodeId: d.taxon_id, descendantIds: allNodeIds });
+					this.$emit("selectTaxon", { nodeId: d.taxon_id, descendantIds: allNodeIds, db: this.db });
 				});
 			;
 

--- a/frontend/SankeyDiagram.vue
+++ b/frontend/SankeyDiagram.vue
@@ -1,6 +1,6 @@
 <template>
 	 <div class="sankey-container">
-        <svg ref="sankeyContainer"></svg>    
+        <svg ref="sankeyContainer" class="hide"></svg>    
         </div>
 </template>
 
@@ -89,7 +89,7 @@ export default {
 			});
 		},
 		// Function for processing/parsing data
-		parseData(data, isFullGraph = true) {
+		parseData(data, isFullGraph = false) {
 			const nodes = [];
 			const unclassifiedNodes = [];
 			const allNodes = [];
@@ -150,49 +150,6 @@ export default {
 						// Append current node to currentLineage array + store lineage data
 						currentLineage.push(node);
 						node.lineage = [...currentLineage];
-					}
-				} else if (this.isUnclassifiedTaxa(d)) {
-					// lineage tracking for unclassified taxa
-					let currentLineageCopy = [...currentLineage];
-					const parentName = d.name.replace("unclassified ", "");
-					let lastLineageNode = currentLineageCopy[currentLineageCopy.length - 1];
-
-					if (lastLineageNode) {
-						while (lastLineageNode && lastLineageNode.name !== parentName) {
-							currentLineageCopy.pop();
-							lastLineageNode = currentLineageCopy[currentLineageCopy.length - 1];
-						}
-					}
-
-					// Find the previous node in the lineage that is in rankOrder
-					const parentNode = currentLineageCopy.find((n) => n.name === parentName);
-					if (parentNode && parentNode === lastLineageNode) {
-						const lineage = currentLineageCopy;
-
-						let previousNode = null;
-						for (let i = lineage.length - 1; i >= 0; i--) {
-							// Start from the last item
-							if (this.rankOrder.includes(lineage[i].rank)) {
-								previousNode = lineage[i];
-								break;
-							}
-						}
-
-						// Determine the rank immediately to the right of this node
-						const parentRankIndex = this.rankOrder.indexOf(previousNode.rank);
-
-						// Edit properties for unclassified taxa
-						const nextRank = this.rankOrder[parentRankIndex + 1];
-
-						node.id = `dummy-${d.taxon_id}`;
-						node.rank = nextRank;
-						node.type = "unclassified";
-
-						// Add unclassified node to currentLineage and save lineage data
-						currentLineageCopy.push(node);
-						node.lineage = [...currentLineageCopy];
-
-						unclassifiedNodes.push(node);
 					}
 				}
 			});
@@ -290,7 +247,8 @@ export default {
 			const svg = d3.select(container)
 			.attr("viewBox", `0 0 ${width} ${height}`)
 			.attr("width", "100%")
-			.attr("height", height);
+			.attr("height", height)
+			.classed("hide", false);
 
 			const sankeyGenerator = sankey()
 				.nodeId((d) => d.id)
@@ -431,7 +389,7 @@ export default {
 						.style("opacity", 1)
 						.html(`
 							<div style="padding-top: 4px; padding-bottom: 4px; padding-left: 8px; padding-right: 8px;">
-								<p style="font-size: 0.6rem; margin-bottom: 0px;">#${d.id}</p>
+								<p style="font-size: 0.6rem; margin-bottom: 0px;">#${d.taxon_id}</p>
 								<div style="display: flex; justify-content: space-between; align-items: center;">
 									<div style="font-weight: bold; font-size: 0.875rem;">${d.name}</div>
 									<span style="background-color: rgba(255, 167, 38, 0.25); color: #ffa726; font-weight: bold; padding: 4px 8px; border-radius: 12px; font-size: 0.875rem; margin-left: 10px;">${d.rank}</span>
@@ -483,7 +441,7 @@ export default {
 
 					// Function to collect all IDs of the current node and its descendants
 					const collectIds = (node) => {
-						let childrenIds = [node.id];
+						let childrenIds = [node.taxon_id];
 						childrenIds = childrenIds.concat(this.findChildren(this.rawData, node));
 						return childrenIds;
 					};
@@ -495,7 +453,7 @@ export default {
         			this.currentSelectedNode = d;
 
 					// Emit the IDs array
-					this.$emit("selectTaxon", { nodeId: d.id, descendantIds: allNodeIds });
+					this.$emit("selectTaxon", { nodeId: d.taxon_id, descendantIds: allNodeIds });
 				});
 			;
 
@@ -574,7 +532,7 @@ export default {
 			for (let i = 0; i < rawData.length; i++) {
 				const d = rawData[i];
 
-				if (d.taxon_id === selectedNode.id) {
+				if (d.taxon_id === selectedNode.taxon_id) {
 					// Start adding child nodes from here
 					startAdding = true;
 					continue; // Move to the next iteration to skip the current node

--- a/frontend/SankeyDiagram.vue
+++ b/frontend/SankeyDiagram.vue
@@ -24,10 +24,10 @@ export default {
 			type: String,
 			required: true,
 		},
-		// currentSelectedDb: {
-		// 	type: String,
-		// 	default: null,
-		// }
+		currentSelectedDb: {
+			type: String,
+			default: null,
+		}
 	},
     data: () => ({
 		currentSelectedNode: null, // Track the currently selected node
@@ -74,13 +74,16 @@ export default {
 				});
 			},
 		},
-		// currentSelectedNodeId(newValue) {
-		// 	if (newValue) {
-		// 		if (newValue !== this.db) {
-		// 			this.currentSelectedNode = null;
-		// 		}
-		// 	}
-		// }
+		currentSelectedDb: {
+			immediate: true,
+			handler(newValue) {
+				if (newValue !== this.db) {
+					// Reset the selected node when switching databases
+					this.currentSelectedNode = null;
+					this.createSankey(this.rawData);
+				}
+			}
+		}
     },
     methods: {
 		// Function for processing/parsing data
@@ -249,6 +252,10 @@ export default {
 			}
 
 			const container = this.$refs.sankeyContainer;
+			if (!container || !container.parentElement) {
+				// Ensure the container and its parent are accessible
+				return;
+			}
 			d3.select(container).selectAll("*").remove(); // Clear the previous diagram
 
 			const nodeWidth = 30;


### PR DESCRIPTION
Changes:
- Added "Show/Hide Taxonomy" button for sankey (hide button for databases that do not generate a taxonomy report)
- Enabled toggling of each taxonomy individually
- Added top 10 rank limit 
- Add some fixes to hits filtering feature (click node to filter hits)

Database with taxonomy report generated:
![image](https://github.com/user-attachments/assets/ce30ba94-c334-4f19-94ed-f81de7aae966)

No taxonomy report (button hidden):
![image](https://github.com/user-attachments/assets/bf7ed9c6-f0ee-498f-b349-e8fb25b3398c)
