### PR TITLE
Add batch Foldseek structure search via /ticket/foldseek/batch

### DIFF
--- a/backend/alignment.go
+++ b/backend/alignment.go
@@ -558,6 +558,27 @@ func FSAlignments(id Id, entry []int64, databases []string, jobsbase string) ([]
 	return ReadAlignments[FoldseekAlignmentEntry, int64](id, entry, databases, jobsbase)
 }
 
+func FSAllAlignments(id Id, databases []string, jobsbase string) ([]SearchResult, error) {
+	base := filepath.Join(jobsbase, string(id))
+	if len(databases) == 0 {
+		return nil, nil
+	}
+	probe := filepath.Join(filepath.Clean(base), "alis_"+databases[0])
+	reader := Reader[uint32]{}
+	err := reader.Make(dbpaths(probe))
+	if err != nil {
+		return nil, err
+	}
+	n := reader.Size()
+	reader.Delete()
+
+	entries := make([]int64, n)
+	for i := int64(0); i < n; i++ {
+		entries[i] = i
+	}
+	return ReadAlignments[FoldseekAlignmentEntry, int64](id, entries, databases, jobsbase)
+}
+
 func ComplexAlignments(id Id, entry []uint32, databases []string, jobsbase string) ([]SearchResult, error) {
 	return ReadAlignments[ComplexAlignmentEntry, uint32](id, entry, databases, jobsbase)
 }

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -18,6 +18,7 @@ type FoldDiscoJob struct {
 	// TaxFilter string `json:"taxfilter"`
 	Motif  string   `json:"motif"`
 	Motifs []string `json:"motifs,omitempty"`
+	Top    int      `json:"top,omitempty"`
 	query  string
 	queries []string
 }
@@ -30,6 +31,7 @@ func (r FoldDiscoJob) Hash() Id {
 	h.Write(([]byte)(JobFoldDisco))
 	h.Write([]byte(r.query))
 	h.Write([]byte(r.Motif))
+	h.Write([]byte(fmt.Sprintf("%d", r.Top)))
 	for _, q := range r.queries {
 		h.Write([]byte(q))
 	}
@@ -100,11 +102,15 @@ func validateFolddiscoDatabases(dbs []string, validDbs []Params) error {
 	return nil
 }
 
-func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
+func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs []Params, resultPath string, email string, top int) (JobRequest, error) {
+	if top <= 0 {
+		top = 1000
+	}
 	job := FoldDiscoJob{
 		Size:     max(strings.Count(query, "HEADER"), 1),
 		Database: dbs,
 		Motif:    motif,
+		Top:      top,
 		query:    query,
 	}
 
@@ -123,7 +129,7 @@ func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs [
 	return request, nil
 }
 
-func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
+func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string, validDbs []Params, resultPath string, email string, top int) (JobRequest, error) {
 	if len(queries) != len(motifs) {
 		return JobRequest{}, errors.New("queries and motifs must have the same length")
 	}
@@ -136,10 +142,14 @@ func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string
 		totalSize += max(strings.Count(q, "HEADER"), 1)
 	}
 
+	if top <= 0 {
+		top = 1000
+	}
 	job := FoldDiscoJob{
 		Size:     totalSize,
 		Database: dbs,
 		Motifs:   motifs,
+		Top:      top,
 		queries:  queries,
 	}
 

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -71,7 +71,7 @@ func (r FoldDiscoJob) WriteBatchFiles(basePath string) error {
 	var lines []string
 	for i, q := range r.queries {
 		ext := ".pdb"
-		if len(q) > 0 && (q[0] == '#' || strings.HasPrefix(q, "data_")) {
+		if len(q) > 0 && ismmCIFFirstLine(strings.TrimSpace(q)) {
 			ext = ".cif"
 		}
 		filename := fmt.Sprintf("job_%d%s", i, ext)

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -88,7 +88,9 @@ func (r FoldDiscoJob) WriteBatchFiles(basePath string) error {
 func validateFolddiscoDatabases(dbs []string, validDbs []Params) error {
 	ids := make([]string, 0)
 	for _, item := range validDbs {
-		ids = append(ids, item.Path)
+		if item.Motif {
+			ids = append(ids, item.Path)
+		}
 	}
 	for _, item := range dbs {
 		if isIn(item, ids) == -1 {

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -14,8 +16,10 @@ type FoldDiscoJob struct {
 	Database []string `json:"database" validate:"required"`
 	// Mode      string   `json:"mode" validate:"oneof=3di tmalign 3diaa"`
 	// TaxFilter string `json:"taxfilter"`
-	Motif string `json:"motif"`
-	query string
+	Motif  string   `json:"motif"`
+	Motifs []string `json:"motifs,omitempty"`
+	query  string
+	queries []string
 }
 
 const FolddiscoCacheVersion string = "v1"
@@ -26,6 +30,12 @@ func (r FoldDiscoJob) Hash() Id {
 	h.Write(([]byte)(JobFoldDisco))
 	h.Write([]byte(r.query))
 	h.Write([]byte(r.Motif))
+	for _, q := range r.queries {
+		h.Write([]byte(q))
+	}
+	for _, m := range r.Motifs {
+		h.Write([]byte(m))
+	}
 	// h.Write([]byte(r.Mode))
 	// if r.TaxFilter != "" {
 	// 	h.Write([]byte(r.TaxFilter))
@@ -53,14 +63,47 @@ func (r FoldDiscoJob) WritePDB(path string) error {
 	return nil
 }
 
+func (r FoldDiscoJob) IsBatch() bool {
+	return len(r.Motifs) > 0
+}
+
+func (r FoldDiscoJob) WriteBatchFiles(basePath string) error {
+	var lines []string
+	for i, q := range r.queries {
+		ext := ".pdb"
+		if len(q) > 0 && (q[0] == '#' || strings.HasPrefix(q, "data_")) {
+			ext = ".cif"
+		}
+		filename := fmt.Sprintf("job_%d%s", i, ext)
+		fp := filepath.Join(basePath, filename)
+		if err := os.WriteFile(fp, []byte(q), 0644); err != nil {
+			return err
+		}
+		lines = append(lines, fp+"\t"+r.Motifs[i])
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(filepath.Join(basePath, "query_batch.txt"), []byte(content), 0644)
+}
+
+func validateFolddiscoDatabases(dbs []string, validDbs []Params) error {
+	ids := make([]string, 0)
+	for _, item := range validDbs {
+		ids = append(ids, item.Path)
+	}
+	for _, item := range dbs {
+		if isIn(item, ids) == -1 {
+			return errors.New("selected databases are not valid")
+		}
+	}
+	return nil
+}
+
 func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
 	job := FoldDiscoJob{
-		max(strings.Count(query, "HEADER"), 1),
-		dbs,
-		// mode,
-		// taxfilter,
-		motif,
-		query,
+		Size:     max(strings.Count(query, "HEADER"), 1),
+		Database: dbs,
+		Motif:    motif,
+		query:    query,
 	}
 
 	request := JobRequest{
@@ -71,23 +114,44 @@ func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs [
 		email,
 	}
 
-	ids := make([]string, 0)
-	for _, item := range validDbs {
-		if item.Motif {
-			ids = append(ids, item.Path)
-		}
+	if err := validateFolddiscoDatabases(dbs, validDbs); err != nil {
+		return request, err
 	}
 
-	for _, item := range job.Database {
-		idx := isIn(item, ids)
-		if idx == -1 {
-			return request, errors.New("selected databases are not valid")
-		}
+	return request, nil
+}
+
+func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
+	if len(queries) != len(motifs) {
+		return JobRequest{}, errors.New("queries and motifs must have the same length")
+	}
+	if len(queries) == 0 {
+		return JobRequest{}, errors.New("at least one query is required")
 	}
 
-	// if !validTaxonFilter(taxfilter) {
-	// 	return request, errors.New("invalid taxon filter")
-	// }
+	totalSize := 0
+	for _, q := range queries {
+		totalSize += max(strings.Count(q, "HEADER"), 1)
+	}
+
+	job := FoldDiscoJob{
+		Size:     totalSize,
+		Database: dbs,
+		Motifs:   motifs,
+		queries:  queries,
+	}
+
+	request := JobRequest{
+		job.Hash(),
+		StatusPending,
+		JobFoldDisco,
+		job,
+		email,
+	}
+
+	if err := validateFolddiscoDatabases(dbs, validDbs); err != nil {
+		return request, err
+	}
 
 	return request, nil
 }

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -16,9 +16,11 @@ type FoldDiscoJob struct {
 	Database []string `json:"database" validate:"required"`
 	// Mode      string   `json:"mode" validate:"oneof=3di tmalign 3diaa"`
 	// TaxFilter string `json:"taxfilter"`
-	Motif  string   `json:"motif"`
-	Motifs []string `json:"motifs,omitempty"`
-	Top    int      `json:"top,omitempty"`
+	Motif  string     `json:"motif"`
+	// Motifs[i] holds one or more motif strings for queries[i].
+	// Each motifs[] form value may contain multiple motifs separated by ";".
+	Motifs [][]string `json:"motifs,omitempty"`
+	Top    int        `json:"top,omitempty"`
 	query  string
 	queries []string
 }
@@ -35,8 +37,10 @@ func (r FoldDiscoJob) Hash() Id {
 	for _, q := range r.queries {
 		h.Write([]byte(q))
 	}
-	for _, m := range r.Motifs {
-		h.Write([]byte(m))
+	for _, ms := range r.Motifs {
+		for _, m := range ms {
+			h.Write([]byte(m))
+		}
 	}
 	// h.Write([]byte(r.Mode))
 	// if r.TaxFilter != "" {
@@ -81,7 +85,10 @@ func (r FoldDiscoJob) WriteBatchFiles(basePath string) error {
 		if err := os.WriteFile(fp, []byte(q), 0644); err != nil {
 			return err
 		}
-		lines = append(lines, fp+"\t"+r.Motifs[i])
+		// Each query can have multiple motifs; emit one batch line per motif.
+		for _, m := range r.Motifs[i] {
+			lines = append(lines, fp+"\t"+m)
+		}
 	}
 	content := strings.Join(lines, "\n") + "\n"
 	return os.WriteFile(filepath.Join(basePath, "query_batch.txt"), []byte(content), 0644)
@@ -129,12 +136,21 @@ func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs [
 	return request, nil
 }
 
-func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string, validDbs []Params, resultPath string, email string, top int) (JobRequest, error) {
+// NewFoldDiscoBatchJobRequest creates a batch Folddisco job. motifs[i] contains
+// the motifs for queries[i]; each entry may hold more than one motif so that a
+// single structure can be searched with multiple motif specifications without
+// re-uploading the file.
+func NewFoldDiscoBatchJobRequest(queries []string, motifs [][]string, dbs []string, validDbs []Params, resultPath string, email string, top int) (JobRequest, error) {
 	if len(queries) != len(motifs) {
 		return JobRequest{}, errors.New("queries and motifs must have the same length")
 	}
 	if len(queries) == 0 {
 		return JobRequest{}, errors.New("at least one query is required")
+	}
+	for i, ms := range motifs {
+		if len(ms) == 0 {
+			return JobRequest{}, fmt.Errorf("query %d has no motifs", i)
+		}
 	}
 
 	totalSize := 0

--- a/backend/jobsystem.go
+++ b/backend/jobsystem.go
@@ -127,6 +127,9 @@ func (m *JobRequest) WriteSupportFiles(base string) error {
 		return errors.New("invalid job type")
 	case JobStructureSearch:
 		if j, ok := m.Job.(StructureSearchJob); ok {
+			if j.IsBatch() {
+				return j.WriteBatchDir(base)
+			}
 			return j.WritePDB(filepath.Join(base, "job.pdb"))
 		}
 		return errors.New("invalid job type")

--- a/backend/jobsystem.go
+++ b/backend/jobsystem.go
@@ -159,6 +159,9 @@ func (m *JobRequest) WriteSupportFiles(base string) error {
 		return errors.New("invalid job type")
 	case JobFoldDisco:
 		if j, ok := m.Job.(FoldDiscoJob); ok {
+			if j.IsBatch() {
+				return j.WriteBatchFiles(base)
+			}
 			return j.WritePDB(filepath.Join(base, "job.pdb"))
 		}
 		return errors.New("invalid job type")

--- a/backend/server.go
+++ b/backend/server.go
@@ -548,6 +548,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		var dbs []string
 		//var mode string
 		var email string
+		var top int
 		//var iterativesearch bool
 		// var taxfilter string
 
@@ -614,6 +615,10 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			// taxfilter = req.FormValue("taxfilter")
 		}
 
+		if topStr := req.FormValue("top"); topStr != "" {
+			top, _ = strconv.Atoi(topStr)
+		}
+
 		databases, err := Databases(config.Paths.Databases, true)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -622,9 +627,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 
 		var request JobRequest
 		if len(queries) > 0 {
-			request, err = NewFoldDiscoBatchJobRequest(queries, motifs, dbs, databases, config.Paths.Results, email)
+			request, err = NewFoldDiscoBatchJobRequest(queries, motifs, dbs, databases, config.Paths.Results, email, top)
 		} else {
-			request, err = NewFoldDiscoJobRequest(query, motif, dbs, databases, config.Paths.Results, email)
+			request, err = NewFoldDiscoJobRequest(query, motif, dbs, databases, config.Paths.Results, email, top)
 		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/backend/server.go
+++ b/backend/server.go
@@ -544,7 +544,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		var query string
 		var motif string
 		var queries []string
-		var motifs []string
+		var rawMotifs []string
 		var dbs []string
 		//var mode string
 		var email string
@@ -577,7 +577,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			}
 
 			if len(queries) > 0 {
-				motifs = req.Form["motifs[]"]
+				rawMotifs = req.Form["motifs[]"]
 			} else {
 				f, _, err := req.FormFile("q")
 				if err != nil {
@@ -602,7 +602,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			}
 
 			queries = req.Form["queries[]"]
-			motifs = req.Form["motifs[]"]
+			rawMotifs = req.Form["motifs[]"]
 
 			if len(queries) == 0 {
 				query = req.FormValue("q")
@@ -623,6 +623,13 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
+		}
+
+		// Each rawMotifs[] entry may contain multiple motifs separated by ";",
+		// allowing a single uploaded structure to be searched with several motifs.
+		var motifs [][]string
+		for _, raw := range rawMotifs {
+			motifs = append(motifs, strings.Split(raw, ";"))
 		}
 
 		var request JobRequest

--- a/backend/server.go
+++ b/backend/server.go
@@ -655,6 +655,82 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		}
 	}
 
+	ticketFoldseekBatchHandlerFunc := func(w http.ResponseWriter, req *http.Request) {
+		var queries []string
+		var dbs []string
+		var mode string
+		var email string
+		var taxfilter string
+
+		if strings.HasPrefix(req.Header.Get("Content-Type"), "multipart/form-data") {
+			err := req.ParseMultipartForm(int64(128 * 1024 * 1024))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			if files := req.MultipartForm.File["queries[]"]; len(files) > 0 {
+				for _, fh := range files {
+					file, err := fh.Open()
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					buf := new(bytes.Buffer)
+					buf.ReadFrom(file)
+					file.Close()
+					queries = append(queries, buf.String())
+				}
+			} else if formQueries := req.Form["queries[]"]; len(formQueries) > 0 {
+				queries = formQueries
+			}
+
+			dbs = req.Form["database[]"]
+			mode = req.FormValue("mode")
+			email = req.FormValue("email")
+			taxfilter = req.FormValue("taxfilter")
+		} else {
+			err := req.ParseForm()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			queries = req.Form["queries[]"]
+			dbs = req.Form["database[]"]
+			mode = req.FormValue("mode")
+			email = req.FormValue("email")
+			taxfilter = req.FormValue("taxfilter")
+		}
+
+		if mode == "" {
+			mode = "3di"
+		}
+
+		databases, err := Databases(config.Paths.Databases, true)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		request, err := NewStructureSearchBatchJobRequest(queries, dbs, databases, mode, config.Paths.Results, email, taxfilter)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		result, err := jobsystem.NewJob(request, config.Paths.Results, false)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		err = json.NewEncoder(w).Encode(result)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
 	if config.Server.RateLimit != nil {
 		type RateLimitResponse struct {
 			Status string `json:"status"`
@@ -689,6 +765,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if config.App == AppFoldseek {
 			r.Handle("/ticket/foldmason", ratelimitWithAllowlistHandler(allowlistedCIDRs, lmt, ticketFoldMasonMSAHandlerFunc)).Methods("POST")
 			r.Handle("/ticket/folddisco", ratelimitWithAllowlistHandler(allowlistedCIDRs, lmt, ticketFolddiscoHandlerFunc)).Methods("POST")
+			r.Handle("/ticket/foldseek/batch", ratelimitWithAllowlistHandler(allowlistedCIDRs, lmt, ticketFoldseekBatchHandlerFunc)).Methods("POST")
 		}
 	} else {
 		if config.App == AppMMseqs2 || config.App == AppFoldseek {
@@ -703,6 +780,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if config.App == AppFoldseek {
 			r.HandleFunc("/ticket/foldmason", ticketFoldMasonMSAHandlerFunc).Methods("POST")
 			r.HandleFunc("/ticket/folddisco", ticketFolddiscoHandlerFunc).Methods("POST")
+			r.HandleFunc("/ticket/foldseek/batch", ticketFoldseekBatchHandlerFunc).Methods("POST")
 		}
 	}
 
@@ -1272,6 +1350,65 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			return
 		}
 	})
+	r.HandleFunc("/result/foldseek/{ticket}", func(w http.ResponseWriter, req *http.Request) {
+		vars := mux.Vars(req)
+		ticket, err := jobsystem.GetTicket(Id(vars["ticket"]))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		status, err := jobsystem.Status(ticket.Id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if status != StatusComplete {
+			http.Error(w, "Job is not complete", http.StatusBadRequest)
+			return
+		}
+
+		resultBase := filepath.Join(config.Paths.Results, string(ticket.Id))
+		request, err := getJobRequestFromFile(filepath.Join(resultBase, "job.json"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		job, ok := request.Job.(StructureSearchJob)
+		if !ok {
+			http.Error(w, "Invalid job type", http.StatusBadRequest)
+			return
+		}
+
+		database := req.URL.Query().Get("database")
+		databases := job.Database
+		if database != "" {
+			if isIn(database, job.Database) == -1 {
+				http.Error(w, "Database not found", http.StatusBadRequest)
+				return
+			}
+			databases = []string{database}
+		}
+
+		results, err := FSAllAlignments(ticket.Id, databases, config.Paths.Results)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		type BatchFoldseekResponse struct {
+			Mode    string         `json:"mode"`
+			Results []SearchResult `json:"results"`
+		}
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		err = json.NewEncoder(w).Encode(BatchFoldseekResponse{job.Mode, results})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}).Methods("GET")
+
 	r.Handle("/result/{ticket}/{entry}", compressHandler(resultHandler)).Methods("GET")
 
 	r.HandleFunc("/result/queries/{ticket}/{limit}/{page}", func(w http.ResponseWriter, req *http.Request) {

--- a/backend/server.go
+++ b/backend/server.go
@@ -543,6 +543,8 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 	ticketFolddiscoHandlerFunc := func(w http.ResponseWriter, req *http.Request) {
 		var query string
 		var motif string
+		var queries []string
+		var motifs []string
 		var dbs []string
 		//var mode string
 		var email string
@@ -556,19 +558,40 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 				return
 			}
 
-			f, _, err := req.FormFile("q")
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
+			// Batch mode: multiple structures via queries[] file fields
+			if files := req.MultipartForm.File["queries[]"]; len(files) > 0 {
+				for _, fh := range files {
+					file, err := fh.Open()
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					buf := new(bytes.Buffer)
+					buf.ReadFrom(file)
+					file.Close()
+					queries = append(queries, buf.String())
+				}
+			} else if formQueries := req.Form["queries[]"]; len(formQueries) > 0 {
+				queries = formQueries
 			}
 
-			buf := new(bytes.Buffer)
-			buf.ReadFrom(f)
-			query = buf.String()
+			if len(queries) > 0 {
+				motifs = req.Form["motifs[]"]
+			} else {
+				f, _, err := req.FormFile("q")
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				buf := new(bytes.Buffer)
+				buf.ReadFrom(f)
+				query = buf.String()
+				motif = req.FormValue("motif")
+			}
+
 			dbs = req.Form["database[]"]
 			//mode = req.FormValue("mode")
 			email = req.FormValue("email")
-			motif = req.FormValue("motif")
 			// taxfilter = req.FormValue("taxfilter")
 		} else {
 			err := req.ParseForm()
@@ -576,11 +599,18 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			query = req.FormValue("q")
+
+			queries = req.Form["queries[]"]
+			motifs = req.Form["motifs[]"]
+
+			if len(queries) == 0 {
+				query = req.FormValue("q")
+				motif = req.FormValue("motif")
+			}
+
 			dbs = req.Form["database[]"]
 			//mode = req.FormValue("mode")
 			email = req.FormValue("email")
-			motif = req.FormValue("motif")
 			// taxfilter = req.FormValue("taxfilter")
 		}
 
@@ -590,7 +620,12 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			return
 		}
 
-		request, err := NewFoldDiscoJobRequest(query, motif, dbs, databases /*mode,*/, config.Paths.Results, email /*, taxfilter*/)
+		var request JobRequest
+		if len(queries) > 0 {
+			request, err = NewFoldDiscoBatchJobRequest(queries, motifs, dbs, databases, config.Paths.Results, email)
+		} else {
+			request, err = NewFoldDiscoJobRequest(query, motif, dbs, databases, config.Paths.Results, email)
+		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/backend/structuresearchjob.go
+++ b/backend/structuresearchjob.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -16,12 +18,20 @@ type StructureSearchJob struct {
 	IterativeSearch bool     `json:"iterativesearch"`
 	TaxFilter       string   `json:"taxfilter"`
 	query           string
+	queries         []string
+}
+
+func (r StructureSearchJob) IsBatch() bool {
+	return len(r.queries) > 0
 }
 
 func (r StructureSearchJob) Hash() Id {
 	h := sha256.New224()
 	h.Write(([]byte)(JobStructureSearch))
 	h.Write([]byte(r.query))
+	for _, q := range r.queries {
+		h.Write([]byte(q))
+	}
 	h.Write([]byte(r.Mode))
 	if r.IterativeSearch {
 		h.Write([]byte("iterative"))
@@ -56,14 +66,80 @@ func (r StructureSearchJob) WritePDB(path string) error {
 	return nil
 }
 
+// WriteBatchDir writes each query structure to a separate file in a
+// "queries" subdirectory. foldseek easy-search accepts a directory as
+// input and will search all structures inside it.
+func (r StructureSearchJob) WriteBatchDir(basePath string) error {
+	dir := filepath.Join(basePath, "queries")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	for i, q := range r.queries {
+		ext := ".pdb"
+		if len(q) > 0 && ismmCIFFirstLine(strings.TrimSpace(q)) {
+			ext = ".cif"
+		}
+		filename := fmt.Sprintf("query_%d%s", i, ext)
+		if err := os.WriteFile(filepath.Join(dir, filename), []byte(q), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func NewStructureSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, iterativeSearch bool, taxfilter string) (JobRequest, error) {
 	job := StructureSearchJob{
-		max(strings.Count(query, "HEADER"), 1),
-		dbs,
-		mode,
-		iterativeSearch,
-		taxfilter,
-		query,
+		Size:            max(strings.Count(query, "HEADER"), 1),
+		Database:        dbs,
+		Mode:            mode,
+		IterativeSearch: iterativeSearch,
+		TaxFilter:       taxfilter,
+		query:           query,
+	}
+
+	request := JobRequest{
+		Id:    job.Hash(),
+		Status: StatusPending,
+		Type:  JobStructureSearch,
+		Job:   job,
+		Email: email,
+	}
+
+	ids := make([]string, len(validDbs))
+	for i, item := range validDbs {
+		ids[i] = item.Path
+	}
+
+	for _, item := range job.Database {
+		idx := isIn(item, ids)
+		if idx == -1 {
+			return request, errors.New("selected databases are not valid")
+		}
+	}
+
+	if !validTaxonFilter(taxfilter) {
+		return request, errors.New("invalid taxon filter")
+	}
+
+	return request, nil
+}
+
+func NewStructureSearchBatchJobRequest(queries []string, dbs []string, validDbs []Params, mode string, resultPath string, email string, taxfilter string) (JobRequest, error) {
+	if len(queries) == 0 {
+		return JobRequest{}, errors.New("at least one query is required")
+	}
+
+	totalSize := 0
+	for _, q := range queries {
+		totalSize += max(strings.Count(q, "HEADER"), 1)
+	}
+
+	job := StructureSearchJob{
+		Size:     totalSize,
+		Database: dbs,
+		Mode:     mode,
+		TaxFilter: taxfilter,
+		queries:  queries,
 	}
 
 	request := JobRequest{
@@ -78,10 +154,8 @@ func NewStructureSearchJobRequest(query string, dbs []string, validDbs []Params,
 	for i, item := range validDbs {
 		ids[i] = item.Path
 	}
-
 	for _, item := range job.Database {
-		idx := isIn(item, ids)
-		if idx == -1 {
+		if isIn(item, ids) == -1 {
 			return request, errors.New("selected databases are not valid")
 		}
 	}

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -133,6 +133,10 @@ func execCommandSync(verbose bool, parameters []string, environ []string, timeou
 
 var fasta3DiInput = regexp.MustCompile(`^>.*?\n.*?\n>3DI.*?\n.*?\n`).MatchString
 
+func ismmCIFFirstLine(line string) bool {
+	return strings.HasPrefix(line, "#") || strings.HasPrefix(line, "data_")
+}
+
 func ismmCIFFile(filePath string) (bool, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -156,10 +160,7 @@ func ismmCIFFile(filePath string) (bool, error) {
 		return false, errors.New("empty file")
 	}
 
-	if strings.HasPrefix(firstLine, "#") || strings.HasPrefix(firstLine, "data_") {
-		return true, nil
-	}
-	return false, nil
+	return ismmCIFFirstLine(firstLine), nil
 }
 
 func RunJob(request JobRequest, config ConfigRoot) (err error) {

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1675,6 +1675,7 @@ rm -rf -- "${BASE}/tmp"
 		}
 
 		motif := job.Motif
+		top := strconv.Itoa(job.Top)
 
 		for index, database := range job.Database {
 			wg.Add(1)
@@ -1720,7 +1721,7 @@ rm -rf -- "${BASE}/tmp"
 						"-q", batchFile,
 						"-i", dbpath,
 						"-o", filepath.Join(resultBase, "alis_"+database),
-						"--top", "1000",
+						"--top", top,
 						"--superpose",
 						"--partial-fit",
 						"-t", strconv.Itoa(threads),
@@ -1733,7 +1734,7 @@ rm -rf -- "${BASE}/tmp"
 						"-q", motif,
 						"-i", dbpath,
 						"-o", filepath.Join(resultBase, "alis_"+database),
-						"--top", "1000",
+						"--top", top,
 						"--superpose",
 						"--partial-fit",
 						"-t", strconv.Itoa(threads),

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1713,18 +1713,19 @@ rm -rf -- "${BASE}/tmp"
 					dbpath = filepath.Clean(params.OverridePath)
 				}
 
+				outputFile := filepath.Join(resultBase, "alis_"+database)
 				var parameters []string
 				if isBatch {
+					// Batch mode: folddisco writes results to stdout, redirect to file via shell
 					parameters = []string{
-						config.Paths.FoldDisco,
-						"query",
-						"-q", batchFile,
-						"-i", dbpath,
-						"-o", filepath.Join(resultBase, "alis_"+database),
-						"--top", top,
-						"--superpose",
-						"--partial-fit",
-						"-t", strconv.Itoa(threads),
+						"sh", "-c",
+						config.Paths.FoldDisco + " query" +
+							" -q " + batchFile +
+							" -i " + dbpath +
+							" --top " + top +
+							" --superpose --partial-fit" +
+							" -t " + strconv.Itoa(threads) +
+							" > " + outputFile,
 					}
 				} else {
 					parameters = []string{

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1756,57 +1756,66 @@ rm -rf -- "${BASE}/tmp"
 				extraArgs := strings.Fields(params.Search)
 
 				if isBatch {
-					// Run each (structure, motif) pair as an individual query
-					// to get proper --top N support and clean per-file output.
+					// Generate a 3-column batch file with per-query output paths
+					// (col3 tells folddisco to write each query's results to its
+					// own file instead of stdout, avoiding interleaved output).
 					batchLines, err := readBatchLines(batchFile)
 					if err != nil {
 						errChan <- &JobExecutionError{err}
 						return
 					}
-					var tempFiles []string
+					var partFiles []string
+					dbBatch := filepath.Join(resultBase, fmt.Sprintf("batch_%s.txt", database))
+					var batchContent strings.Builder
 					for i, bl := range batchLines {
-						tmp := filepath.Join(resultBase, fmt.Sprintf("alis_%s_part_%d", database, i))
-						tempFiles = append(tempFiles, tmp)
-						parameters := []string{
-							config.Paths.FoldDisco,
-							"query",
-							"-p", bl.Structure,
-							"-q", bl.Motif,
-							"-i", dbpath,
-							"-o", tmp,
-							"--top", top,
-							"--superpose",
-							"--partial-fit",
-							"-t", strconv.Itoa(threads),
-						}
-						parameters = append(parameters, extraArgs...)
+						partFile := filepath.Join(resultBase, fmt.Sprintf("alis_%s_part_%d", database, i))
+						partFiles = append(partFiles, partFile)
+						batchContent.WriteString(bl.Structure + "\t" + bl.Motif + "\t" + partFile + "\n")
+					}
+					if err := os.WriteFile(dbBatch, []byte(batchContent.String()), 0644); err != nil {
+						errChan <- &JobExecutionError{err}
+						return
+					}
 
-						cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+					parameters := []string{
+						config.Paths.FoldDisco,
+						"query",
+						"-q", dbBatch,
+						"-i", dbpath,
+						"--top", top,
+						"--superpose",
+						"--partial-fit",
+						"-t", strconv.Itoa(threads),
+					}
+					parameters = append(parameters, extraArgs...)
+
+					cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+					if err != nil {
+						errChan <- &JobExecutionError{err}
+						return
+					}
+					select {
+					case <-time.After(1 * time.Hour):
+						if err := KillCommand(cmd); err != nil {
+							log.Printf("Failed to kill: %s\n", err)
+						}
+						errChan <- &JobTimeoutError{}
+						return
+					case err := <-done:
 						if err != nil {
 							errChan <- &JobExecutionError{err}
 							return
 						}
-						select {
-						case <-time.After(1 * time.Hour):
-							if err := KillCommand(cmd); err != nil {
-								log.Printf("Failed to kill: %s\n", err)
-							}
-							errChan <- &JobTimeoutError{}
-							return
-						case err := <-done:
-							if err != nil {
-								errChan <- &JobExecutionError{err}
-								return
-							}
-						}
 					}
-					if err := concatFiles(tempFiles, outputFile); err != nil {
+
+					if err := concatFiles(partFiles, outputFile); err != nil {
 						errChan <- &JobExecutionError{err}
 						return
 					}
-					for _, tmp := range tempFiles {
-						os.Remove(tmp)
+					for _, f := range partFiles {
+						os.Remove(f)
 					}
+					os.Remove(dbBatch)
 				} else {
 					parameters := []string{
 						config.Paths.FoldDisco,

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -360,14 +360,23 @@ func RunJob(request JobRequest, config ConfigRoot) (err error) {
 		maxParallel := config.Worker.ParallelDatabases
 		semaphore := make(chan struct{}, max(1, maxParallel))
 
+		queriesDir := filepath.Join(resultBase, "queries")
+		isBatch := fileExists(queriesDir)
 		inputFile := filepath.Join(resultBase, "job.pdb")
-		input, err := os.ReadFile(inputFile)
-		if err != nil {
-			return &JobExecutionError{err}
+		if isBatch {
+			inputFile = queriesDir
 		}
 
 		is3Di := false
-		if fasta3DiInput(string(input)) {
+		if !isBatch {
+			input, err := os.ReadFile(inputFile)
+			if err != nil {
+				return &JobExecutionError{err}
+			}
+			is3Di = fasta3DiInput(string(input))
+		}
+
+		if is3Di {
 			os.Rename(inputFile, filepath.Join(resultBase, "job.3di"))
 			inputFile = filepath.Join(resultBase, "query")
 			is3Di = true
@@ -412,7 +421,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 			if err != nil {
 				return &JobExecutionError{err}
 			}
-		} else {
+		} else if !isBatch {
 			isCif, err := ismmCIFFile(inputFile)
 			if err != nil {
 				return &JobExecutionError{err}

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1654,19 +1654,23 @@ rm -rf -- "${BASE}/tmp"
 		maxParallel := config.Worker.ParallelDatabases
 		semaphore := make(chan struct{}, max(1, maxParallel))
 
-		inputFile := filepath.Join(resultBase, "job.pdb")
+		isBatch := job.IsBatch()
+		inputFile := ""
+		batchFile := filepath.Join(resultBase, "query_batch.txt")
 
-		isCif, err := ismmCIFFile(inputFile)
-		if err != nil {
-			return &JobExecutionError{err}
-		}
-
-		if isCif {
-			newFilePath := filepath.Join(resultBase, "job.cif")
-			if err := os.Rename(inputFile, newFilePath); err != nil {
+		if !isBatch {
+			inputFile = filepath.Join(resultBase, "job.pdb")
+			isCif, err := ismmCIFFile(inputFile)
+			if err != nil {
 				return &JobExecutionError{err}
 			}
-			inputFile = newFilePath
+			if isCif {
+				newFilePath := filepath.Join(resultBase, "job.cif")
+				if err := os.Rename(inputFile, newFilePath); err != nil {
+					return &JobExecutionError{err}
+				}
+				inputFile = newFilePath
+			}
 		}
 
 		motif := job.Motif
@@ -1682,12 +1686,6 @@ rm -rf -- "${BASE}/tmp"
 					errChan <- &JobExecutionError{err}
 					return
 				}
-				if !params.Motif {
-					err := errors.New("Database is not a folddisco database")
-					errChan <- &JobExecutionError{err}
-					return
-				}
-
 				threads := 16
 				for _, kv := range os.Environ() {
 					if strings.HasPrefix(kv, "MMSEQS_NUM_THREADS=") {
@@ -1712,22 +1710,33 @@ rm -rf -- "${BASE}/tmp"
 				if params.OverridePath != "" {
 					dbpath = filepath.Clean(params.OverridePath)
 				}
-				parameters := []string{
-					config.Paths.FoldDisco,
-					"query",
-					"-p",
-					inputFile,
-					"-q", motif,
-					"-i",
-					dbpath,
-					"-o",
-					filepath.Join(resultBase, "alis_"+database),
-					"--top",
-					"1000",
-					"--superpose",
-					"--partial-fit",
-					"-t",
-					strconv.Itoa(threads),
+
+				var parameters []string
+				if isBatch {
+					parameters = []string{
+						config.Paths.FoldDisco,
+						"query",
+						"-q", batchFile,
+						"-i", dbpath,
+						"-o", filepath.Join(resultBase, "alis_"+database),
+						"--top", "1000",
+						"--superpose",
+						"--partial-fit",
+						"-t", strconv.Itoa(threads),
+					}
+				} else {
+					parameters = []string{
+						config.Paths.FoldDisco,
+						"query",
+						"-p", inputFile,
+						"-q", motif,
+						"-i", dbpath,
+						"-o", filepath.Join(resultBase, "alis_"+database),
+						"--top", "1000",
+						"--superpose",
+						"--partial-fit",
+						"-t", strconv.Itoa(threads),
+					}
 				}
 				parameters = append(parameters, strings.Fields(params.Search)...)
 

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -137,6 +137,45 @@ func ismmCIFFirstLine(line string) bool {
 	return strings.HasPrefix(line, "#") || strings.HasPrefix(line, "data_")
 }
 
+type batchLine struct {
+	Structure string
+	Motif     string
+}
+
+func readBatchLines(path string) ([]batchLine, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var lines []batchLine
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		lines = append(lines, batchLine{Structure: parts[0], Motif: parts[1]})
+	}
+	return lines, nil
+}
+
+func concatFiles(srcs []string, dst string) error {
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	for _, src := range srcs {
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return err
+		}
+		if _, err := out.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func ismmCIFFile(filePath string) (bool, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -1714,136 +1753,177 @@ rm -rf -- "${BASE}/tmp"
 				}
 
 				outputFile := filepath.Join(resultBase, "alis_"+database)
-				var parameters []string
+				extraArgs := strings.Fields(params.Search)
+
 				if isBatch {
-					// Batch mode: folddisco writes results to stdout, redirect to file via shell.
-					// Use -t 1 to avoid interleaved output from concurrent queries.
-					parameters = []string{
-						"sh", "-c",
-						config.Paths.FoldDisco + " query" +
-							" -q " + batchFile +
-							" -i " + dbpath +
-							" --top " + top +
-							" --superpose --partial-fit" +
-							" -t 1" +
-							" > " + outputFile,
+					// Run each (structure, motif) pair as an individual query
+					// to get proper --top N support and clean per-file output.
+					batchLines, err := readBatchLines(batchFile)
+					if err != nil {
+						errChan <- &JobExecutionError{err}
+						return
+					}
+					var tempFiles []string
+					for i, bl := range batchLines {
+						tmp := filepath.Join(resultBase, fmt.Sprintf("alis_%s_part_%d", database, i))
+						tempFiles = append(tempFiles, tmp)
+						parameters := []string{
+							config.Paths.FoldDisco,
+							"query",
+							"-p", bl.Structure,
+							"-q", bl.Motif,
+							"-i", dbpath,
+							"-o", tmp,
+							"--top", top,
+							"--superpose",
+							"--partial-fit",
+							"-t", strconv.Itoa(threads),
+						}
+						parameters = append(parameters, extraArgs...)
+
+						cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+						if err != nil {
+							errChan <- &JobExecutionError{err}
+							return
+						}
+						select {
+						case <-time.After(1 * time.Hour):
+							if err := KillCommand(cmd); err != nil {
+								log.Printf("Failed to kill: %s\n", err)
+							}
+							errChan <- &JobTimeoutError{}
+							return
+						case err := <-done:
+							if err != nil {
+								errChan <- &JobExecutionError{err}
+								return
+							}
+						}
+					}
+					if err := concatFiles(tempFiles, outputFile); err != nil {
+						errChan <- &JobExecutionError{err}
+						return
+					}
+					for _, tmp := range tempFiles {
+						os.Remove(tmp)
 					}
 				} else {
-					parameters = []string{
+					parameters := []string{
 						config.Paths.FoldDisco,
 						"query",
 						"-p", inputFile,
 						"-q", motif,
 						"-i", dbpath,
-						"-o", filepath.Join(resultBase, "alis_"+database),
+						"-o", outputFile,
 						"--top", top,
 						"--superpose",
 						"--partial-fit",
 						"-t", strconv.Itoa(threads),
 					}
-				}
-				parameters = append(parameters, strings.Fields(params.Search)...)
+					parameters = append(parameters, extraArgs...)
 
-				cmd, done, err := execCommand(config.Verbose, parameters, []string{})
-				if err != nil {
-					errChan <- &JobExecutionError{err}
-					return
-				}
-
-				select {
-				case <-time.After(1 * time.Hour):
-					if err := KillCommand(cmd); err != nil {
-						log.Printf("Failed to kill: %s\n", err)
-					}
-					errChan <- &JobTimeoutError{}
-				case err := <-done:
+					cmd, done, err := execCommand(config.Verbose, parameters, []string{})
 					if err != nil {
 						errChan <- &JobExecutionError{err}
-					} else {
-						if params.FullHeader || params.Taxonomy {
-							foldseekDb := strings.Replace(dbpath, "_folddisco", "", 1)
-							if fileExists(foldseekDb + ".dbtype") {
-								columns := "bits"
-								if params.FullHeader {
-									columns += ",theader"
-								} else {
-									columns += ",empty"
-								}
-								if params.Taxonomy {
-									columns += ",taxid,taxname"
-								}
-								// make fake foldseek dbs so we can call convertalis for description and taxonomy
-								parameters = []string{
-									"awk",
-									"-v",
-									"db=" + filepath.Join(resultBase, "alis_"+database+"_db"),
-									`BEGIN { printf("") > db; printf("") > db"_seq"; printf("") > db"_seq_h"; }
+						return
+					}
+					select {
+					case <-time.After(1 * time.Hour):
+						if err := KillCommand(cmd); err != nil {
+							log.Printf("Failed to kill: %s\n", err)
+						}
+						errChan <- &JobTimeoutError{}
+						return
+					case err := <-done:
+						if err != nil {
+							errChan <- &JobExecutionError{err}
+							return
+						}
+					}
+				}
+
+				// Post-processing: convertalis for headers/taxonomy
+				if params.FullHeader || params.Taxonomy {
+					foldseekDb := strings.Replace(dbpath, "_folddisco", "", 1)
+					if fileExists(foldseekDb + ".dbtype") {
+						columns := "bits"
+						if params.FullHeader {
+							columns += ",theader"
+						} else {
+							columns += ",empty"
+						}
+						if params.Taxonomy {
+							columns += ",taxid,taxname"
+						}
+						// make fake foldseek dbs so we can call convertalis for description and taxonomy
+						err = execCommandSync(
+							config.Verbose,
+							[]string{
+								"awk",
+								"-v",
+								"db=" + filepath.Join(resultBase, "alis_"+database+"_db"),
+								`BEGIN { printf("") > db; printf("") > db"_seq"; printf("") > db"_seq_h"; }
 !($9 in f) { entry = $9"\t"$9"\t0.00\t0\t0\t0\t0\t0\t0\t0\t0"; print(entry) >> db; len += length(entry) + 1; f[$9] = 1; }
 END { printf("%c", 0) >> db; printf("%c", 0) >> db"_seq"; printf("%c", 0) >> db"_seq_h";
 print "0\t0\t"(len + 1) > db".index"; print "0\t0\t0" > db"_seq.index"; print "0\t0\t0" > db"_seq_h.index";
 printf("%c%c%c%c",5,0,0,0) > db".dbtype"; printf("%c%c%c%c",0,0,0,0) > db"_seq.dbtype"; printf("%c%c%c%c",11,0,0,0) > db"_seq_h.dbtype"
 }`,
-									filepath.Join(resultBase, "alis_"+database),
-								}
-								err = execCommandSync(
-									config.Verbose,
-									parameters,
-									[]string{},
-									1*time.Minute,
-								)
-								if err != nil {
-									errChan <- &JobExecutionError{err}
-									return
-								}
-								err = execCommandSync(
-									config.Verbose,
-									[]string{
-										config.Paths.Foldseek,
-										"convertalis",
-										filepath.Join(resultBase, "alis_"+database+"_db_seq"),
-										foldseekDb,
-										filepath.Join(resultBase, "alis_"+database+"_db"),
-										filepath.Join(resultBase, "alis_"+database+".tsv"),
-										"--format-output",
-										columns,
-										"--db-load-mode",
-										"2",
-										"--db-output",
-										"0",
-									},
-									[]string{},
-									1*time.Minute,
-								)
-								if err != nil {
-									errChan <- &JobExecutionError{err}
-									return
-								}
-								if params.Taxonomy {
-									err = execCommandSync(
-										config.Verbose,
-										[]string{
-											config.Paths.Foldseek,
-											"taxonomyreport",
-											foldseekDb,
-											filepath.Join(resultBase, "alis_"+database+"_db"),
-											filepath.Join(resultBase, "alis_"+database+"_report"),
-											"--report-mode",
-											"3",
-										},
-										[]string{},
-										1*time.Minute,
-									)
-									if err != nil {
-										errChan <- &JobExecutionError{err}
-										return
-									}
-								}
+								filepath.Join(resultBase, "alis_"+database),
+							},
+							[]string{},
+							1*time.Minute,
+						)
+						if err != nil {
+							errChan <- &JobExecutionError{err}
+							return
+						}
+						err = execCommandSync(
+							config.Verbose,
+							[]string{
+								config.Paths.Foldseek,
+								"convertalis",
+								filepath.Join(resultBase, "alis_"+database+"_db_seq"),
+								foldseekDb,
+								filepath.Join(resultBase, "alis_"+database+"_db"),
+								filepath.Join(resultBase, "alis_"+database+".tsv"),
+								"--format-output",
+								columns,
+								"--db-load-mode",
+								"2",
+								"--db-output",
+								"0",
+							},
+							[]string{},
+							1*time.Minute,
+						)
+						if err != nil {
+							errChan <- &JobExecutionError{err}
+							return
+						}
+						if params.Taxonomy {
+							err = execCommandSync(
+								config.Verbose,
+								[]string{
+									config.Paths.Foldseek,
+									"taxonomyreport",
+									foldseekDb,
+									filepath.Join(resultBase, "alis_"+database+"_db"),
+									filepath.Join(resultBase, "alis_"+database+"_report"),
+									"--report-mode",
+									"3",
+								},
+								[]string{},
+								1*time.Minute,
+							)
+							if err != nil {
+								errChan <- &JobExecutionError{err}
+								return
 							}
 						}
-
-						errChan <- nil
 					}
 				}
+
+				errChan <- nil
 			}(index, database)
 		}
 

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1716,7 +1716,8 @@ rm -rf -- "${BASE}/tmp"
 				outputFile := filepath.Join(resultBase, "alis_"+database)
 				var parameters []string
 				if isBatch {
-					// Batch mode: folddisco writes results to stdout, redirect to file via shell
+					// Batch mode: folddisco writes results to stdout, redirect to file via shell.
+					// Use -t 1 to avoid interleaved output from concurrent queries.
 					parameters = []string{
 						"sh", "-c",
 						config.Paths.FoldDisco + " query" +
@@ -1724,7 +1725,7 @@ rm -rf -- "${BASE}/tmp"
 							" -i " + dbpath +
 							" --top " + top +
 							" --superpose --partial-fit" +
-							" -t " + strconv.Itoa(threads) +
+							" -t 1" +
 							" > " + outputFile,
 					}
 				} else {


### PR DESCRIPTION
## Summary
- New endpoint `POST /ticket/foldseek/batch` accepts `queries[]` (multiple uploaded structure files), `database[]`, `mode`, `email`, and `taxfilter`
- Query structures are written to a `queries/` directory and passed to `foldseek easy-search`, which natively handles multi-query directory input and produces per-query entries in the output alignment DB
- New `GET /result/foldseek/{ticket}` endpoint returns all per-query results by reading all entries from the alignment DB, reusing the existing `ReadAlignments` infrastructure
- Worker detects batch mode by checking for the `queries/` directory on disk (unexported struct fields aren't preserved across JSON serialization)
- Route uses `/ticket/foldseek/batch` to avoid gorilla/mux v1.8.0 405 conflict with the existing `/ticket/{ticket}` variable route

## Example usage

```bash
curl -X POST http://host/api/ticket/foldseek/batch \
  -F "queries[]=@structure1.pdb" \
  -F "queries[]=@structure2.cif" \
  -F "database[]=PDB" \
  -F "mode=3di"

# Check results
curl http://host/api/result/foldseek/{ticket_id}
```

## Test plan
- [x] Batch query with 2 structures against PDB (tmalign mode) — returned 41 alignments per query
- [x] Folddisco batch mode still works correctly
- [x] Single-query foldseek via existing `/ticket` endpoint unaffected
