### PR TITLE
Group batch folddisco results by query/motif pair

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -24,6 +24,8 @@ ARG FOLDDISCO_HASH=folddisco
 # ARG FOLDDISCO_HASH=archive/7514114fb6c444c0483e20838a0a06688304918e
 ONBUILD ADD https://mmseqs.com/${FOLDDISCO_HASH}/folddisco-linux-x86_64.tar.gz .
 ONBUILD ADD https://mmseqs.com/foldcomp/foldcomp-linux-x86_64.tar.gz .
+ARG FOLDSEEK_INTERFACE_HASH=foldseek_interface-tmp
+ONBUILD ADD https://steineggerlab-hidden.s3.us-east-1.amazonaws.com/foldseek_interface-beta/foldseek-interface-linux-x86_64.tar.gz .
 
 FROM scratch AS foldseek_arm64_downloader
 WORKDIR /opt/build
@@ -64,7 +66,7 @@ RUN mkdir binaries; \
         fi; \
       done; \
     else \
-      for i in mmseqs foldseek foldmason folddisco foldcomp; do \
+      for i in mmseqs foldseek foldmason folddisco foldcomp foldseekinterface; do \
         for j in sse2 sse41 avx2 x86_64; do \
           if [ -e "${i}-linux-${j}.tar.gz" ]; then \
             cat ${i}-linux-${j}.tar.gz | tar -xzvf- ${i}/bin/${i}; \

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -24,7 +24,7 @@ ARG FOLDDISCO_HASH=folddisco
 # ARG FOLDDISCO_HASH=archive/7514114fb6c444c0483e20838a0a06688304918e
 ONBUILD ADD https://mmseqs.com/${FOLDDISCO_HASH}/folddisco-linux-x86_64.tar.gz .
 ONBUILD ADD https://mmseqs.com/foldcomp/foldcomp-linux-x86_64.tar.gz .
-ARG FOLDSEEK_INTERFACE_HASH=foldseek_interface-tmp
+ARG FOLDSEEK_INTERFACE_HASH=foldseek-interface
 ONBUILD ADD https://steineggerlab-hidden.s3.us-east-1.amazonaws.com/foldseek_interface-beta/foldseek-interface-linux-x86_64.tar.gz .
 
 FROM scratch AS foldseek_arm64_downloader
@@ -66,7 +66,7 @@ RUN mkdir binaries; \
         fi; \
       done; \
     else \
-      for i in mmseqs foldseek foldmason folddisco foldcomp foldseekinterface; do \
+      for i in mmseqs foldseek foldmason folddisco foldcomp foldseek-interface; do \
         for j in sse2 sse41 avx2 x86_64; do \
           if [ -e "${i}-linux-${j}.tar.gz" ]; then \
             cat ${i}-linux-${j}.tar.gz | tar -xzvf- ${i}/bin/${i}; \

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -24,8 +24,6 @@ ARG FOLDDISCO_HASH=folddisco
 # ARG FOLDDISCO_HASH=archive/7514114fb6c444c0483e20838a0a06688304918e
 ONBUILD ADD https://mmseqs.com/${FOLDDISCO_HASH}/folddisco-linux-x86_64.tar.gz .
 ONBUILD ADD https://mmseqs.com/foldcomp/foldcomp-linux-x86_64.tar.gz .
-ARG FOLDSEEK_INTERFACE_HASH=foldseek-interface
-ONBUILD ADD https://steineggerlab-hidden.s3.us-east-1.amazonaws.com/foldseek_interface-beta/foldseek-interface-linux-x86_64.tar.gz .
 
 FROM scratch AS foldseek_arm64_downloader
 WORKDIR /opt/build
@@ -66,16 +64,13 @@ RUN mkdir binaries; \
         fi; \
       done; \
     else \
-      for i in mmseqs foldseek foldmason folddisco foldcomp foldseek-interface; do \
+      for i in mmseqs foldseek foldmason folddisco foldcomp ; do \
         for j in sse2 sse41 avx2 x86_64; do \
           if [ -e "${i}-linux-${j}.tar.gz" ]; then \
             cat ${i}-linux-${j}.tar.gz | tar -xzvf- ${i}/bin/${i}; \
             if [ "$i" = "folddisco" ] ; then \
               mv -f -- ${i}/bin/${i} binaries/${i}; \
             elif [ "$i" = "foldcomp" ]; then \
-              cat ${i}-linux-${j}.tar.gz | tar -xzvf- ${i}; \
-              mv -f -- ${i} binaries/${i}; \
-            elif [ "$i" = "foldseek-interface" ]; then \
               cat ${i}-linux-${j}.tar.gz | tar -xzvf- ${i}; \
               mv -f -- ${i} binaries/${i}; \
             else \

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -76,7 +76,8 @@ RUN mkdir binaries; \
               cat ${i}-linux-${j}.tar.gz | tar -xzvf- ${i}; \
               mv -f -- ${i} binaries/${i}; \
             elif [ "$i" = "foldseek-interface" ]; then \
-              mv -f -- ${i}/bin/${i} binaries/${i}; \
+              cat ${i}-linux-${j}.tar.gz | tar -xzvf- ${i}; \
+              mv -f -- ${i} binaries/${i}; \
             else \
               mv -f -- ${i}/bin/${i} binaries/${i}_${j}; \
             fi; \

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -75,6 +75,8 @@ RUN mkdir binaries; \
             elif [ "$i" = "foldcomp" ]; then \
               cat ${i}-linux-${j}.tar.gz | tar -xzvf- ${i}; \
               mv -f -- ${i} binaries/${i}; \
+            elif [ "$i" = "foldseek-interface" ]; then \
+              mv -f -- ${i}/bin/${i} binaries/${i}; \
             else \
               mv -f -- ${i}/bin/${i} binaries/${i}_${j}; \
             fi; \

--- a/backend/alignment.go
+++ b/backend/alignment.go
@@ -225,6 +225,19 @@ type FoldDiscoResult struct {
 	TaxonomyReports interface{}               `json:"taxonomyreports"`
 }
 
+type FoldDiscoQueryResult struct {
+	QueryIndex int                        `json:"query_index"`
+	Motif      string                     `json:"motif"`
+	Alignments []FoldDiscoAlignmentEntry  `json:"alignments"`
+	Meta       []FolddiscoMeta           `json:"meta,omitempty"`
+}
+
+type FoldDiscoBatchResult struct {
+	Database        string                  `json:"db"`
+	Queries         []FoldDiscoQueryResult  `json:"queries"`
+	TaxonomyReports interface{}             `json:"taxonomyreports"`
+}
+
 type EmptyEntry struct{}
 
 type FastaEntry struct {
@@ -488,6 +501,120 @@ func ReadFoldDisco(id Id, databases []string, jobsbase string) ([]FoldDiscoResul
 	}
 
 	return res, nil
+}
+
+func ReadFoldDiscoBatch(id Id, databases []string, jobsbase string, batchManifest []BatchEntry) ([]FoldDiscoBatchResult, error) {
+	base := filepath.Join(jobsbase, string(id))
+	taxonomyReader := Reader[uint32]{}
+
+	res := make([]FoldDiscoBatchResult, 0, len(databases))
+
+	for _, db := range databases {
+		alisBase := filepath.Join(filepath.Clean(base), "alis_"+db)
+
+		// Read shared meta from the concatenated file's .tsv
+		allMeta := make(map[uint32]FolddiscoMeta)
+		metafile := alisBase + ".tsv"
+		if fileExists(metafile) {
+			file, err := os.Open(metafile)
+			if err != nil {
+				return nil, fmt.Errorf("result file not found")
+			}
+			defer file.Close()
+
+			metaSlice, err := ReadAlignment[FolddiscoMeta](file)
+			if err != nil {
+				return res, err
+			}
+			for _, m := range metaSlice {
+				allMeta[m.TargetKey] = m
+			}
+		}
+
+		// Read shared taxonomy
+		allTaxonomyReports := make([][]TaxonomyReport, 0)
+		if fileExists(alisBase + "_report") {
+			err := taxonomyReader.Make(dbpaths(alisBase + "_report"))
+			if err != nil {
+				return res, err
+			}
+			taxBody := taxonomyReader.Data(0)
+			taxResult, err := ReadTaxonomyReport(taxBody)
+			if err != nil {
+				taxonomyReader.Delete()
+				return nil, err
+			}
+			allTaxonomyReports = append(allTaxonomyReports, taxResult)
+			taxonomyReader.Delete()
+		}
+
+		// Read per-query part files
+		queries := make([]FoldDiscoQueryResult, 0, len(batchManifest))
+		for i, entry := range batchManifest {
+			partPath := filepath.Join(filepath.Clean(base), fmt.Sprintf("alis_%s_part_%d", db, i))
+
+			var alignments []FoldDiscoAlignmentEntry
+			if fileExists(partPath) {
+				file, err := os.Open(partPath)
+				if err != nil {
+					return nil, fmt.Errorf("result part file not found: %s", partPath)
+				}
+				defer file.Close()
+
+				alignments, err = ReadAlignment[FoldDiscoAlignmentEntry](file)
+				if err != nil {
+					return res, err
+				}
+			}
+
+			// Filter meta to only keys present in this query's alignments
+			var queryMeta []FolddiscoMeta
+			if len(allMeta) > 0 {
+				seen := make(map[uint32]bool)
+				for _, a := range alignments {
+					key := uint32(a.DbKey)
+					if !seen[key] {
+						if m, ok := allMeta[key]; ok {
+							queryMeta = append(queryMeta, m)
+						}
+						seen[key] = true
+					}
+				}
+			}
+
+			queries = append(queries, FoldDiscoQueryResult{
+				QueryIndex: i,
+				Motif:      entry.Motif,
+				Alignments: alignments,
+				Meta:       queryMeta,
+			})
+		}
+
+		res = append(res, FoldDiscoBatchResult{db, queries, allTaxonomyReports})
+	}
+
+	return res, nil
+}
+
+type BatchEntry struct {
+	Structure string
+	Motif     string
+}
+
+func ReadBatchManifest(path string) ([]BatchEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var entries []BatchEntry
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) < 2 {
+			continue
+		}
+		entries = append(entries, BatchEntry{Structure: parts[0], Motif: parts[1]})
+	}
+	return entries, nil
 }
 
 func ReadTaxonomyReport(taxBody string) ([]TaxonomyReport, error) {

--- a/backend/config.go
+++ b/backend/config.go
@@ -341,6 +341,7 @@ func ReadConfig(r io.Reader, relativeTo string) (ConfigRoot, error) {
 		paths = append(
 			paths,
 			&config.Paths.Foldseek,
+			&config.Paths.FoldseekInterface,
 			&config.Paths.FoldMason,
 			&config.Paths.FoldDisco,
 			&config.Paths.FoldComp,

--- a/backend/config.go
+++ b/backend/config.go
@@ -389,9 +389,9 @@ func (c *ConfigRoot) CheckPaths() error {
 		if _, err := os.Stat(c.Paths.FoldDisco); err != nil {
 			return errors.New("FoldDisco binary was not found at " + c.Paths.FoldDisco)
 		}
-		// if _, err := os.Stat(c.Paths.FoldseekInterface); err != nil {
-		// 	return errors.New("FoldseekInterface binary was not found at " + c.Paths.FoldseekInterface)
-		// }
+		if _, err := os.Stat(c.Paths.FoldseekInterface); err != nil {
+			return errors.New("FoldseekInterface binary was not found at " + c.Paths.FoldseekInterface)
+		}
 	} else if _, err := os.Stat(c.Paths.Mmseqs); err != nil {
 		return errors.New("MMseqs2 binary was not found at " + c.Paths.Mmseqs)
 	}

--- a/backend/config.go
+++ b/backend/config.go
@@ -389,9 +389,9 @@ func (c *ConfigRoot) CheckPaths() error {
 		if _, err := os.Stat(c.Paths.FoldDisco); err != nil {
 			return errors.New("FoldDisco binary was not found at " + c.Paths.FoldDisco)
 		}
-		if _, err := os.Stat(c.Paths.FoldseekInterface); err != nil {
-			return errors.New("FoldseekInterface binary was not found at " + c.Paths.FoldseekInterface)
-		}
+		// if _, err := os.Stat(c.Paths.FoldseekInterface); err != nil {
+		// 	return errors.New("FoldseekInterface binary was not found at " + c.Paths.FoldseekInterface)
+		// }
 	} else if _, err := os.Stat(c.Paths.Mmseqs); err != nil {
 		return errors.New("MMseqs2 binary was not found at " + c.Paths.Mmseqs)
 	}

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -18,6 +18,7 @@ type FoldDiscoJob struct {
 	// TaxFilter string `json:"taxfilter"`
 	Motif  string   `json:"motif"`
 	Motifs []string `json:"motifs,omitempty"`
+	Top    int      `json:"top,omitempty"`
 	query  string
 	queries []string
 }
@@ -30,6 +31,7 @@ func (r FoldDiscoJob) Hash() Id {
 	h.Write(([]byte)(JobFoldDisco))
 	h.Write([]byte(r.query))
 	h.Write([]byte(r.Motif))
+	h.Write([]byte(fmt.Sprintf("%d", r.Top)))
 	for _, q := range r.queries {
 		h.Write([]byte(q))
 	}
@@ -100,11 +102,15 @@ func validateFolddiscoDatabases(dbs []string, validDbs []Params) error {
 	return nil
 }
 
-func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
+func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs []Params, resultPath string, email string, top int) (JobRequest, error) {
+	if top <= 0 {
+		top = 1000
+	}
 	job := FoldDiscoJob{
 		Size:     max(strings.Count(query, "HEADER"), 1),
 		Database: dbs,
 		Motif:    motif,
+		Top:      top,
 		query:    query,
 	}
 
@@ -123,7 +129,7 @@ func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs [
 	return request, nil
 }
 
-func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
+func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string, validDbs []Params, resultPath string, email string, top int) (JobRequest, error) {
 	if len(queries) != len(motifs) {
 		return JobRequest{}, errors.New("queries and motifs must have the same length")
 	}
@@ -136,10 +142,14 @@ func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string
 		totalSize += max(strings.Count(q, "HEADER"), 1)
 	}
 
+	if top <= 0 {
+		top = 1000
+	}
 	job := FoldDiscoJob{
 		Size:     totalSize,
 		Database: dbs,
 		Motifs:   motifs,
+		Top:      top,
 		queries:  queries,
 	}
 

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -71,7 +71,7 @@ func (r FoldDiscoJob) WriteBatchFiles(basePath string) error {
 	var lines []string
 	for i, q := range r.queries {
 		ext := ".pdb"
-		if len(q) > 0 && (q[0] == '#' || strings.HasPrefix(q, "data_")) {
+		if len(q) > 0 && ismmCIFFirstLine(strings.TrimSpace(q)) {
 			ext = ".cif"
 		}
 		filename := fmt.Sprintf("job_%d%s", i, ext)

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -88,7 +88,9 @@ func (r FoldDiscoJob) WriteBatchFiles(basePath string) error {
 func validateFolddiscoDatabases(dbs []string, validDbs []Params) error {
 	ids := make([]string, 0)
 	for _, item := range validDbs {
-		ids = append(ids, item.Path)
+		if item.Motif {
+			ids = append(ids, item.Path)
+		}
 	}
 	for _, item := range dbs {
 		if isIn(item, ids) == -1 {

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -14,8 +16,10 @@ type FoldDiscoJob struct {
 	Database []string `json:"database" validate:"required"`
 	// Mode      string   `json:"mode" validate:"oneof=3di tmalign 3diaa"`
 	// TaxFilter string `json:"taxfilter"`
-	Motif string `json:"motif"`
-	query string
+	Motif  string   `json:"motif"`
+	Motifs []string `json:"motifs,omitempty"`
+	query  string
+	queries []string
 }
 
 const FolddiscoCacheVersion string = "v1"
@@ -26,6 +30,12 @@ func (r FoldDiscoJob) Hash() Id {
 	h.Write(([]byte)(JobFoldDisco))
 	h.Write([]byte(r.query))
 	h.Write([]byte(r.Motif))
+	for _, q := range r.queries {
+		h.Write([]byte(q))
+	}
+	for _, m := range r.Motifs {
+		h.Write([]byte(m))
+	}
 	// h.Write([]byte(r.Mode))
 	// if r.TaxFilter != "" {
 	// 	h.Write([]byte(r.TaxFilter))
@@ -53,14 +63,47 @@ func (r FoldDiscoJob) WritePDB(path string) error {
 	return nil
 }
 
+func (r FoldDiscoJob) IsBatch() bool {
+	return len(r.Motifs) > 0
+}
+
+func (r FoldDiscoJob) WriteBatchFiles(basePath string) error {
+	var lines []string
+	for i, q := range r.queries {
+		ext := ".pdb"
+		if len(q) > 0 && (q[0] == '#' || strings.HasPrefix(q, "data_")) {
+			ext = ".cif"
+		}
+		filename := fmt.Sprintf("job_%d%s", i, ext)
+		fp := filepath.Join(basePath, filename)
+		if err := os.WriteFile(fp, []byte(q), 0644); err != nil {
+			return err
+		}
+		lines = append(lines, fp+"\t"+r.Motifs[i])
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(filepath.Join(basePath, "query_batch.txt"), []byte(content), 0644)
+}
+
+func validateFolddiscoDatabases(dbs []string, validDbs []Params) error {
+	ids := make([]string, 0)
+	for _, item := range validDbs {
+		ids = append(ids, item.Path)
+	}
+	for _, item := range dbs {
+		if isIn(item, ids) == -1 {
+			return errors.New("selected databases are not valid")
+		}
+	}
+	return nil
+}
+
 func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
 	job := FoldDiscoJob{
-		max(strings.Count(query, "HEADER"), 1),
-		dbs,
-		// mode,
-		// taxfilter,
-		motif,
-		query,
+		Size:     max(strings.Count(query, "HEADER"), 1),
+		Database: dbs,
+		Motif:    motif,
+		query:    query,
 	}
 
 	request := JobRequest{
@@ -71,23 +114,44 @@ func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs [
 		email,
 	}
 
-	ids := make([]string, 0)
-	for _, item := range validDbs {
-		if item.Motif {
-			ids = append(ids, item.Path)
-		}
+	if err := validateFolddiscoDatabases(dbs, validDbs); err != nil {
+		return request, err
 	}
 
-	for _, item := range job.Database {
-		idx := isIn(item, ids)
-		if idx == -1 {
-			return request, errors.New("selected databases are not valid")
-		}
+	return request, nil
+}
+
+func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
+	if len(queries) != len(motifs) {
+		return JobRequest{}, errors.New("queries and motifs must have the same length")
+	}
+	if len(queries) == 0 {
+		return JobRequest{}, errors.New("at least one query is required")
 	}
 
-	// if !validTaxonFilter(taxfilter) {
-	// 	return request, errors.New("invalid taxon filter")
-	// }
+	totalSize := 0
+	for _, q := range queries {
+		totalSize += max(strings.Count(q, "HEADER"), 1)
+	}
+
+	job := FoldDiscoJob{
+		Size:     totalSize,
+		Database: dbs,
+		Motifs:   motifs,
+		queries:  queries,
+	}
+
+	request := JobRequest{
+		job.Hash(),
+		StatusPending,
+		JobFoldDisco,
+		job,
+		email,
+	}
+
+	if err := validateFolddiscoDatabases(dbs, validDbs); err != nil {
+		return request, err
+	}
 
 	return request, nil
 }

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -16,9 +16,11 @@ type FoldDiscoJob struct {
 	Database []string `json:"database" validate:"required"`
 	// Mode      string   `json:"mode" validate:"oneof=3di tmalign 3diaa"`
 	// TaxFilter string `json:"taxfilter"`
-	Motif  string   `json:"motif"`
-	Motifs []string `json:"motifs,omitempty"`
-	Top    int      `json:"top,omitempty"`
+	Motif  string     `json:"motif"`
+	// Motifs[i] holds one or more motif strings for queries[i].
+	// Each motifs[] form value may contain multiple motifs separated by ";".
+	Motifs [][]string `json:"motifs,omitempty"`
+	Top    int        `json:"top,omitempty"`
 	query  string
 	queries []string
 }
@@ -35,8 +37,10 @@ func (r FoldDiscoJob) Hash() Id {
 	for _, q := range r.queries {
 		h.Write([]byte(q))
 	}
-	for _, m := range r.Motifs {
-		h.Write([]byte(m))
+	for _, ms := range r.Motifs {
+		for _, m := range ms {
+			h.Write([]byte(m))
+		}
 	}
 	// h.Write([]byte(r.Mode))
 	// if r.TaxFilter != "" {
@@ -81,7 +85,10 @@ func (r FoldDiscoJob) WriteBatchFiles(basePath string) error {
 		if err := os.WriteFile(fp, []byte(q), 0644); err != nil {
 			return err
 		}
-		lines = append(lines, fp+"\t"+r.Motifs[i])
+		// Each query can have multiple motifs; emit one batch line per motif.
+		for _, m := range r.Motifs[i] {
+			lines = append(lines, fp+"\t"+m)
+		}
 	}
 	content := strings.Join(lines, "\n") + "\n"
 	return os.WriteFile(filepath.Join(basePath, "query_batch.txt"), []byte(content), 0644)
@@ -129,12 +136,21 @@ func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs [
 	return request, nil
 }
 
-func NewFoldDiscoBatchJobRequest(queries []string, motifs []string, dbs []string, validDbs []Params, resultPath string, email string, top int) (JobRequest, error) {
+// NewFoldDiscoBatchJobRequest creates a batch Folddisco job. motifs[i] contains
+// the motifs for queries[i]; each entry may hold more than one motif so that a
+// single structure can be searched with multiple motif specifications without
+// re-uploading the file.
+func NewFoldDiscoBatchJobRequest(queries []string, motifs [][]string, dbs []string, validDbs []Params, resultPath string, email string, top int) (JobRequest, error) {
 	if len(queries) != len(motifs) {
 		return JobRequest{}, errors.New("queries and motifs must have the same length")
 	}
 	if len(queries) == 0 {
 		return JobRequest{}, errors.New("at least one query is required")
+	}
+	for i, ms := range motifs {
+		if len(ms) == 0 {
+			return JobRequest{}, fmt.Errorf("query %d has no motifs", i)
+		}
 	}
 
 	totalSize := 0

--- a/backend/jobsystem.go
+++ b/backend/jobsystem.go
@@ -159,6 +159,9 @@ func (m *JobRequest) WriteSupportFiles(base string) error {
 		return errors.New("invalid job type")
 	case JobFoldDisco:
 		if j, ok := m.Job.(FoldDiscoJob); ok {
+			if j.IsBatch() {
+				return j.WriteBatchFiles(base)
+			}
 			return j.WritePDB(filepath.Join(base, "job.pdb"))
 		}
 		return errors.New("invalid job type")

--- a/backend/lookup.go
+++ b/backend/lookup.go
@@ -32,7 +32,7 @@ func Lookup(ticketId Id, page uint64, limit uint64, basepath string, shouldGroup
 		return LookupResponse{}, err
 	}
 
-	isComplex := request.Type == JobComplexSearch && shouldGroup
+	isComplex := request.Type == JobComplexSearch || request.Type == JobInterfaceSearch && shouldGroup
 
 	results := make([]LookupResult, 0)
 	res := LookupResult{}

--- a/backend/server.go
+++ b/backend/server.go
@@ -914,15 +914,42 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 					}
 					databases = []string{database}
 				}
-				results, err = FoldDiscoAlignments(ticket.Id, databases, config.Paths.Results)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
 
-				for _, res := range results {
-					if res.Alignments == nil {
-						continue
+				w.Header().Set("Cache-Control", "public, max-age=3600")
+
+				if job.IsBatch() {
+					manifest, err := ReadBatchManifest(filepath.Join(resultBase, "query_batch.txt"))
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					batchResults, err := ReadFoldDiscoBatch(ticket.Id, databases, config.Paths.Results, manifest)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					type FoldDiscoBatchModeResponse struct {
+						Results []FoldDiscoBatchResult `json:"results"`
+					}
+					err = json.NewEncoder(w).Encode(FoldDiscoBatchModeResponse{batchResults})
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+				} else {
+					results, err = FoldDiscoAlignments(ticket.Id, databases, config.Paths.Results)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					type FoldDiscoModeResponse struct {
+						Motif   string            `json:"motif"`
+						Results []FoldDiscoResult `json:"results"`
+					}
+					err = json.NewEncoder(w).Encode(FoldDiscoModeResponse{motif, results})
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
 					}
 				}
 			default:
@@ -981,18 +1008,6 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("Cache-Control", "public, max-age=3600")
 			w.Write(pdb)
-			return
-		}
-
-		type FoldDiscoModeResponse struct {
-			// Mode    string            `json:"mode"`
-			Motif   string            `json:"motif"`
-			Results []FoldDiscoResult `json:"results"`
-		}
-		w.Header().Set("Cache-Control", "public, max-age=3600")
-		err = json.NewEncoder(w).Encode(FoldDiscoModeResponse{motif, results})
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}).Methods("GET")

--- a/backend/server.go
+++ b/backend/server.go
@@ -548,6 +548,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		var dbs []string
 		//var mode string
 		var email string
+		var top int
 		//var iterativesearch bool
 		// var taxfilter string
 
@@ -614,6 +615,10 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			// taxfilter = req.FormValue("taxfilter")
 		}
 
+		if topStr := req.FormValue("top"); topStr != "" {
+			top, _ = strconv.Atoi(topStr)
+		}
+
 		databases, err := Databases(config.Paths.Databases, true)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -622,9 +627,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 
 		var request JobRequest
 		if len(queries) > 0 {
-			request, err = NewFoldDiscoBatchJobRequest(queries, motifs, dbs, databases, config.Paths.Results, email)
+			request, err = NewFoldDiscoBatchJobRequest(queries, motifs, dbs, databases, config.Paths.Results, email, top)
 		} else {
-			request, err = NewFoldDiscoJobRequest(query, motif, dbs, databases, config.Paths.Results, email)
+			request, err = NewFoldDiscoJobRequest(query, motif, dbs, databases, config.Paths.Results, email, top)
 		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/backend/server.go
+++ b/backend/server.go
@@ -544,7 +544,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		var query string
 		var motif string
 		var queries []string
-		var motifs []string
+		var rawMotifs []string
 		var dbs []string
 		//var mode string
 		var email string
@@ -577,7 +577,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			}
 
 			if len(queries) > 0 {
-				motifs = req.Form["motifs[]"]
+				rawMotifs = req.Form["motifs[]"]
 			} else {
 				f, _, err := req.FormFile("q")
 				if err != nil {
@@ -602,7 +602,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			}
 
 			queries = req.Form["queries[]"]
-			motifs = req.Form["motifs[]"]
+			rawMotifs = req.Form["motifs[]"]
 
 			if len(queries) == 0 {
 				query = req.FormValue("q")
@@ -623,6 +623,13 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
+		}
+
+		// Each rawMotifs[] entry may contain multiple motifs separated by ";",
+		// allowing a single uploaded structure to be searched with several motifs.
+		var motifs [][]string
+		for _, raw := range rawMotifs {
+			motifs = append(motifs, strings.Split(raw, ";"))
 		}
 
 		var request JobRequest

--- a/backend/server.go
+++ b/backend/server.go
@@ -543,6 +543,8 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 	ticketFolddiscoHandlerFunc := func(w http.ResponseWriter, req *http.Request) {
 		var query string
 		var motif string
+		var queries []string
+		var motifs []string
 		var dbs []string
 		//var mode string
 		var email string
@@ -556,19 +558,40 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 				return
 			}
 
-			f, _, err := req.FormFile("q")
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
+			// Batch mode: multiple structures via queries[] file fields
+			if files := req.MultipartForm.File["queries[]"]; len(files) > 0 {
+				for _, fh := range files {
+					file, err := fh.Open()
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					buf := new(bytes.Buffer)
+					buf.ReadFrom(file)
+					file.Close()
+					queries = append(queries, buf.String())
+				}
+			} else if formQueries := req.Form["queries[]"]; len(formQueries) > 0 {
+				queries = formQueries
 			}
 
-			buf := new(bytes.Buffer)
-			buf.ReadFrom(f)
-			query = buf.String()
+			if len(queries) > 0 {
+				motifs = req.Form["motifs[]"]
+			} else {
+				f, _, err := req.FormFile("q")
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				buf := new(bytes.Buffer)
+				buf.ReadFrom(f)
+				query = buf.String()
+				motif = req.FormValue("motif")
+			}
+
 			dbs = req.Form["database[]"]
 			//mode = req.FormValue("mode")
 			email = req.FormValue("email")
-			motif = req.FormValue("motif")
 			// taxfilter = req.FormValue("taxfilter")
 		} else {
 			err := req.ParseForm()
@@ -576,11 +599,18 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			query = req.FormValue("q")
+
+			queries = req.Form["queries[]"]
+			motifs = req.Form["motifs[]"]
+
+			if len(queries) == 0 {
+				query = req.FormValue("q")
+				motif = req.FormValue("motif")
+			}
+
 			dbs = req.Form["database[]"]
 			//mode = req.FormValue("mode")
 			email = req.FormValue("email")
-			motif = req.FormValue("motif")
 			// taxfilter = req.FormValue("taxfilter")
 		}
 
@@ -590,7 +620,12 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			return
 		}
 
-		request, err := NewFoldDiscoJobRequest(query, motif, dbs, databases /*mode,*/, config.Paths.Results, email /*, taxfilter*/)
+		var request JobRequest
+		if len(queries) > 0 {
+			request, err = NewFoldDiscoBatchJobRequest(queries, motifs, dbs, databases, config.Paths.Results, email)
+		} else {
+			request, err = NewFoldDiscoJobRequest(query, motif, dbs, databases, config.Paths.Results, email)
+		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -887,8 +887,6 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 					"--db-output",
 					"--db-load-mode",
 					"2",
-					"--write-lookup",
-					"1",
 					"--format-output",
 					columns,
 					"--complex-report-mode",
@@ -947,7 +945,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 			[]string{
 				config.Paths.Foldseek,
 				"mvdb",
-				filepath.Join(resultBase, "tmp0", "latest", "query_h"),
+				filepath.Join(resultBase, "tmp0", "latest", "interfacedb_query_h"),
 				filepath.Join(resultBase, "query_h"),
 			},
 			[]string{},
@@ -961,8 +959,21 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 			[]string{
 				config.Paths.Foldseek,
 				"mvdb",
-				filepath.Join(resultBase, "tmp0", "latest", "query"),
+				filepath.Join(resultBase, "tmp0", "latest", "interfacedb_query"),
 				filepath.Join(resultBase, "query"),
+			},
+			[]string{},
+			1*time.Minute,
+		)
+		if err != nil {
+			return &JobExecutionError{err}
+		}
+		err = execCommandSync(
+			config.Verbose,
+			[]string{
+				"mv",
+				filepath.Join(resultBase, "tmp0", "latest", "dimerdb_query.lookup"),
+				filepath.Join(resultBase, "query.lookup"),
 			},
 			[]string{},
 			1*time.Minute,

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -133,6 +133,10 @@ func execCommandSync(verbose bool, parameters []string, environ []string, timeou
 
 var fasta3DiInput = regexp.MustCompile(`^>.*?\n.*?\n>3DI.*?\n.*?\n`).MatchString
 
+func ismmCIFFirstLine(line string) bool {
+	return strings.HasPrefix(line, "#") || strings.HasPrefix(line, "data_")
+}
+
 func ismmCIFFile(filePath string) (bool, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -156,10 +160,7 @@ func ismmCIFFile(filePath string) (bool, error) {
 		return false, errors.New("empty file")
 	}
 
-	if strings.HasPrefix(firstLine, "#") || strings.HasPrefix(firstLine, "data_") {
-		return true, nil
-	}
-	return false, nil
+	return ismmCIFFirstLine(firstLine), nil
 }
 
 func RunJob(request JobRequest, config ConfigRoot) (err error) {

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1675,6 +1675,7 @@ rm -rf -- "${BASE}/tmp"
 		}
 
 		motif := job.Motif
+		top := strconv.Itoa(job.Top)
 
 		for index, database := range job.Database {
 			wg.Add(1)
@@ -1720,7 +1721,7 @@ rm -rf -- "${BASE}/tmp"
 						"-q", batchFile,
 						"-i", dbpath,
 						"-o", filepath.Join(resultBase, "alis_"+database),
-						"--top", "1000",
+						"--top", top,
 						"--superpose",
 						"--partial-fit",
 						"-t", strconv.Itoa(threads),
@@ -1733,7 +1734,7 @@ rm -rf -- "${BASE}/tmp"
 						"-q", motif,
 						"-i", dbpath,
 						"-o", filepath.Join(resultBase, "alis_"+database),
-						"--top", "1000",
+						"--top", top,
 						"--superpose",
 						"--partial-fit",
 						"-t", strconv.Itoa(threads),

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1713,18 +1713,19 @@ rm -rf -- "${BASE}/tmp"
 					dbpath = filepath.Clean(params.OverridePath)
 				}
 
+				outputFile := filepath.Join(resultBase, "alis_"+database)
 				var parameters []string
 				if isBatch {
+					// Batch mode: folddisco writes results to stdout, redirect to file via shell
 					parameters = []string{
-						config.Paths.FoldDisco,
-						"query",
-						"-q", batchFile,
-						"-i", dbpath,
-						"-o", filepath.Join(resultBase, "alis_"+database),
-						"--top", top,
-						"--superpose",
-						"--partial-fit",
-						"-t", strconv.Itoa(threads),
+						"sh", "-c",
+						config.Paths.FoldDisco + " query" +
+							" -q " + batchFile +
+							" -i " + dbpath +
+							" --top " + top +
+							" --superpose --partial-fit" +
+							" -t " + strconv.Itoa(threads) +
+							" > " + outputFile,
 					}
 				} else {
 					parameters = []string{

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1756,57 +1756,66 @@ rm -rf -- "${BASE}/tmp"
 				extraArgs := strings.Fields(params.Search)
 
 				if isBatch {
-					// Run each (structure, motif) pair as an individual query
-					// to get proper --top N support and clean per-file output.
+					// Generate a 3-column batch file with per-query output paths
+					// (col3 tells folddisco to write each query's results to its
+					// own file instead of stdout, avoiding interleaved output).
 					batchLines, err := readBatchLines(batchFile)
 					if err != nil {
 						errChan <- &JobExecutionError{err}
 						return
 					}
-					var tempFiles []string
+					var partFiles []string
+					dbBatch := filepath.Join(resultBase, fmt.Sprintf("batch_%s.txt", database))
+					var batchContent strings.Builder
 					for i, bl := range batchLines {
-						tmp := filepath.Join(resultBase, fmt.Sprintf("alis_%s_part_%d", database, i))
-						tempFiles = append(tempFiles, tmp)
-						parameters := []string{
-							config.Paths.FoldDisco,
-							"query",
-							"-p", bl.Structure,
-							"-q", bl.Motif,
-							"-i", dbpath,
-							"-o", tmp,
-							"--top", top,
-							"--superpose",
-							"--partial-fit",
-							"-t", strconv.Itoa(threads),
-						}
-						parameters = append(parameters, extraArgs...)
+						partFile := filepath.Join(resultBase, fmt.Sprintf("alis_%s_part_%d", database, i))
+						partFiles = append(partFiles, partFile)
+						batchContent.WriteString(bl.Structure + "\t" + bl.Motif + "\t" + partFile + "\n")
+					}
+					if err := os.WriteFile(dbBatch, []byte(batchContent.String()), 0644); err != nil {
+						errChan <- &JobExecutionError{err}
+						return
+					}
 
-						cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+					parameters := []string{
+						config.Paths.FoldDisco,
+						"query",
+						"-q", dbBatch,
+						"-i", dbpath,
+						"--top", top,
+						"--superpose",
+						"--partial-fit",
+						"-t", strconv.Itoa(threads),
+					}
+					parameters = append(parameters, extraArgs...)
+
+					cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+					if err != nil {
+						errChan <- &JobExecutionError{err}
+						return
+					}
+					select {
+					case <-time.After(1 * time.Hour):
+						if err := KillCommand(cmd); err != nil {
+							log.Printf("Failed to kill: %s\n", err)
+						}
+						errChan <- &JobTimeoutError{}
+						return
+					case err := <-done:
 						if err != nil {
 							errChan <- &JobExecutionError{err}
 							return
 						}
-						select {
-						case <-time.After(1 * time.Hour):
-							if err := KillCommand(cmd); err != nil {
-								log.Printf("Failed to kill: %s\n", err)
-							}
-							errChan <- &JobTimeoutError{}
-							return
-						case err := <-done:
-							if err != nil {
-								errChan <- &JobExecutionError{err}
-								return
-							}
-						}
 					}
-					if err := concatFiles(tempFiles, outputFile); err != nil {
+
+					if err := concatFiles(partFiles, outputFile); err != nil {
 						errChan <- &JobExecutionError{err}
 						return
 					}
-					for _, tmp := range tempFiles {
-						os.Remove(tmp)
+					for _, f := range partFiles {
+						os.Remove(f)
 					}
+					os.Remove(dbBatch)
 				} else {
 					parameters := []string{
 						config.Paths.FoldDisco,

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1654,19 +1654,23 @@ rm -rf -- "${BASE}/tmp"
 		maxParallel := config.Worker.ParallelDatabases
 		semaphore := make(chan struct{}, max(1, maxParallel))
 
-		inputFile := filepath.Join(resultBase, "job.pdb")
+		isBatch := job.IsBatch()
+		inputFile := ""
+		batchFile := filepath.Join(resultBase, "query_batch.txt")
 
-		isCif, err := ismmCIFFile(inputFile)
-		if err != nil {
-			return &JobExecutionError{err}
-		}
-
-		if isCif {
-			newFilePath := filepath.Join(resultBase, "job.cif")
-			if err := os.Rename(inputFile, newFilePath); err != nil {
+		if !isBatch {
+			inputFile = filepath.Join(resultBase, "job.pdb")
+			isCif, err := ismmCIFFile(inputFile)
+			if err != nil {
 				return &JobExecutionError{err}
 			}
-			inputFile = newFilePath
+			if isCif {
+				newFilePath := filepath.Join(resultBase, "job.cif")
+				if err := os.Rename(inputFile, newFilePath); err != nil {
+					return &JobExecutionError{err}
+				}
+				inputFile = newFilePath
+			}
 		}
 
 		motif := job.Motif
@@ -1682,12 +1686,6 @@ rm -rf -- "${BASE}/tmp"
 					errChan <- &JobExecutionError{err}
 					return
 				}
-				if !params.Motif {
-					err := errors.New("Database is not a folddisco database")
-					errChan <- &JobExecutionError{err}
-					return
-				}
-
 				threads := 16
 				for _, kv := range os.Environ() {
 					if strings.HasPrefix(kv, "MMSEQS_NUM_THREADS=") {
@@ -1712,22 +1710,33 @@ rm -rf -- "${BASE}/tmp"
 				if params.OverridePath != "" {
 					dbpath = filepath.Clean(params.OverridePath)
 				}
-				parameters := []string{
-					config.Paths.FoldDisco,
-					"query",
-					"-p",
-					inputFile,
-					"-q", motif,
-					"-i",
-					dbpath,
-					"-o",
-					filepath.Join(resultBase, "alis_"+database),
-					"--top",
-					"1000",
-					"--superpose",
-					"--partial-fit",
-					"-t",
-					strconv.Itoa(threads),
+
+				var parameters []string
+				if isBatch {
+					parameters = []string{
+						config.Paths.FoldDisco,
+						"query",
+						"-q", batchFile,
+						"-i", dbpath,
+						"-o", filepath.Join(resultBase, "alis_"+database),
+						"--top", "1000",
+						"--superpose",
+						"--partial-fit",
+						"-t", strconv.Itoa(threads),
+					}
+				} else {
+					parameters = []string{
+						config.Paths.FoldDisco,
+						"query",
+						"-p", inputFile,
+						"-q", motif,
+						"-i", dbpath,
+						"-o", filepath.Join(resultBase, "alis_"+database),
+						"--top", "1000",
+						"--superpose",
+						"--partial-fit",
+						"-t", strconv.Itoa(threads),
+					}
 				}
 				parameters = append(parameters, strings.Fields(params.Search)...)
 

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1823,9 +1823,6 @@ rm -rf -- "${BASE}/tmp"
 						errChan <- &JobExecutionError{err}
 						return
 					}
-					for _, f := range partFiles {
-						os.Remove(f)
-					}
 					os.Remove(dbBatch)
 				} else {
 					parameters := []string{

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -137,6 +137,45 @@ func ismmCIFFirstLine(line string) bool {
 	return strings.HasPrefix(line, "#") || strings.HasPrefix(line, "data_")
 }
 
+type batchLine struct {
+	Structure string
+	Motif     string
+}
+
+func readBatchLines(path string) ([]batchLine, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var lines []batchLine
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		lines = append(lines, batchLine{Structure: parts[0], Motif: parts[1]})
+	}
+	return lines, nil
+}
+
+func concatFiles(srcs []string, dst string) error {
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	for _, src := range srcs {
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return err
+		}
+		if _, err := out.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func ismmCIFFile(filePath string) (bool, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -1714,136 +1753,177 @@ rm -rf -- "${BASE}/tmp"
 				}
 
 				outputFile := filepath.Join(resultBase, "alis_"+database)
-				var parameters []string
+				extraArgs := strings.Fields(params.Search)
+
 				if isBatch {
-					// Batch mode: folddisco writes results to stdout, redirect to file via shell.
-					// Use -t 1 to avoid interleaved output from concurrent queries.
-					parameters = []string{
-						"sh", "-c",
-						config.Paths.FoldDisco + " query" +
-							" -q " + batchFile +
-							" -i " + dbpath +
-							" --top " + top +
-							" --superpose --partial-fit" +
-							" -t 1" +
-							" > " + outputFile,
+					// Run each (structure, motif) pair as an individual query
+					// to get proper --top N support and clean per-file output.
+					batchLines, err := readBatchLines(batchFile)
+					if err != nil {
+						errChan <- &JobExecutionError{err}
+						return
+					}
+					var tempFiles []string
+					for i, bl := range batchLines {
+						tmp := filepath.Join(resultBase, fmt.Sprintf("alis_%s_part_%d", database, i))
+						tempFiles = append(tempFiles, tmp)
+						parameters := []string{
+							config.Paths.FoldDisco,
+							"query",
+							"-p", bl.Structure,
+							"-q", bl.Motif,
+							"-i", dbpath,
+							"-o", tmp,
+							"--top", top,
+							"--superpose",
+							"--partial-fit",
+							"-t", strconv.Itoa(threads),
+						}
+						parameters = append(parameters, extraArgs...)
+
+						cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+						if err != nil {
+							errChan <- &JobExecutionError{err}
+							return
+						}
+						select {
+						case <-time.After(1 * time.Hour):
+							if err := KillCommand(cmd); err != nil {
+								log.Printf("Failed to kill: %s\n", err)
+							}
+							errChan <- &JobTimeoutError{}
+							return
+						case err := <-done:
+							if err != nil {
+								errChan <- &JobExecutionError{err}
+								return
+							}
+						}
+					}
+					if err := concatFiles(tempFiles, outputFile); err != nil {
+						errChan <- &JobExecutionError{err}
+						return
+					}
+					for _, tmp := range tempFiles {
+						os.Remove(tmp)
 					}
 				} else {
-					parameters = []string{
+					parameters := []string{
 						config.Paths.FoldDisco,
 						"query",
 						"-p", inputFile,
 						"-q", motif,
 						"-i", dbpath,
-						"-o", filepath.Join(resultBase, "alis_"+database),
+						"-o", outputFile,
 						"--top", top,
 						"--superpose",
 						"--partial-fit",
 						"-t", strconv.Itoa(threads),
 					}
-				}
-				parameters = append(parameters, strings.Fields(params.Search)...)
+					parameters = append(parameters, extraArgs...)
 
-				cmd, done, err := execCommand(config.Verbose, parameters, []string{})
-				if err != nil {
-					errChan <- &JobExecutionError{err}
-					return
-				}
-
-				select {
-				case <-time.After(1 * time.Hour):
-					if err := KillCommand(cmd); err != nil {
-						log.Printf("Failed to kill: %s\n", err)
-					}
-					errChan <- &JobTimeoutError{}
-				case err := <-done:
+					cmd, done, err := execCommand(config.Verbose, parameters, []string{})
 					if err != nil {
 						errChan <- &JobExecutionError{err}
-					} else {
-						if params.FullHeader || params.Taxonomy {
-							foldseekDb := strings.Replace(dbpath, "_folddisco", "", 1)
-							if fileExists(foldseekDb + ".dbtype") {
-								columns := "bits"
-								if params.FullHeader {
-									columns += ",theader"
-								} else {
-									columns += ",empty"
-								}
-								if params.Taxonomy {
-									columns += ",taxid,taxname"
-								}
-								// make fake foldseek dbs so we can call convertalis for description and taxonomy
-								parameters = []string{
-									"awk",
-									"-v",
-									"db=" + filepath.Join(resultBase, "alis_"+database+"_db"),
-									`BEGIN { printf("") > db; printf("") > db"_seq"; printf("") > db"_seq_h"; }
+						return
+					}
+					select {
+					case <-time.After(1 * time.Hour):
+						if err := KillCommand(cmd); err != nil {
+							log.Printf("Failed to kill: %s\n", err)
+						}
+						errChan <- &JobTimeoutError{}
+						return
+					case err := <-done:
+						if err != nil {
+							errChan <- &JobExecutionError{err}
+							return
+						}
+					}
+				}
+
+				// Post-processing: convertalis for headers/taxonomy
+				if params.FullHeader || params.Taxonomy {
+					foldseekDb := strings.Replace(dbpath, "_folddisco", "", 1)
+					if fileExists(foldseekDb + ".dbtype") {
+						columns := "bits"
+						if params.FullHeader {
+							columns += ",theader"
+						} else {
+							columns += ",empty"
+						}
+						if params.Taxonomy {
+							columns += ",taxid,taxname"
+						}
+						// make fake foldseek dbs so we can call convertalis for description and taxonomy
+						err = execCommandSync(
+							config.Verbose,
+							[]string{
+								"awk",
+								"-v",
+								"db=" + filepath.Join(resultBase, "alis_"+database+"_db"),
+								`BEGIN { printf("") > db; printf("") > db"_seq"; printf("") > db"_seq_h"; }
 !($9 in f) { entry = $9"\t"$9"\t0.00\t0\t0\t0\t0\t0\t0\t0\t0"; print(entry) >> db; len += length(entry) + 1; f[$9] = 1; }
 END { printf("%c", 0) >> db; printf("%c", 0) >> db"_seq"; printf("%c", 0) >> db"_seq_h";
 print "0\t0\t"(len + 1) > db".index"; print "0\t0\t0" > db"_seq.index"; print "0\t0\t0" > db"_seq_h.index";
 printf("%c%c%c%c",5,0,0,0) > db".dbtype"; printf("%c%c%c%c",0,0,0,0) > db"_seq.dbtype"; printf("%c%c%c%c",11,0,0,0) > db"_seq_h.dbtype"
 }`,
-									filepath.Join(resultBase, "alis_"+database),
-								}
-								err = execCommandSync(
-									config.Verbose,
-									parameters,
-									[]string{},
-									1*time.Minute,
-								)
-								if err != nil {
-									errChan <- &JobExecutionError{err}
-									return
-								}
-								err = execCommandSync(
-									config.Verbose,
-									[]string{
-										config.Paths.Foldseek,
-										"convertalis",
-										filepath.Join(resultBase, "alis_"+database+"_db_seq"),
-										foldseekDb,
-										filepath.Join(resultBase, "alis_"+database+"_db"),
-										filepath.Join(resultBase, "alis_"+database+".tsv"),
-										"--format-output",
-										columns,
-										"--db-load-mode",
-										"2",
-										"--db-output",
-										"0",
-									},
-									[]string{},
-									1*time.Minute,
-								)
-								if err != nil {
-									errChan <- &JobExecutionError{err}
-									return
-								}
-								if params.Taxonomy {
-									err = execCommandSync(
-										config.Verbose,
-										[]string{
-											config.Paths.Foldseek,
-											"taxonomyreport",
-											foldseekDb,
-											filepath.Join(resultBase, "alis_"+database+"_db"),
-											filepath.Join(resultBase, "alis_"+database+"_report"),
-											"--report-mode",
-											"3",
-										},
-										[]string{},
-										1*time.Minute,
-									)
-									if err != nil {
-										errChan <- &JobExecutionError{err}
-										return
-									}
-								}
+								filepath.Join(resultBase, "alis_"+database),
+							},
+							[]string{},
+							1*time.Minute,
+						)
+						if err != nil {
+							errChan <- &JobExecutionError{err}
+							return
+						}
+						err = execCommandSync(
+							config.Verbose,
+							[]string{
+								config.Paths.Foldseek,
+								"convertalis",
+								filepath.Join(resultBase, "alis_"+database+"_db_seq"),
+								foldseekDb,
+								filepath.Join(resultBase, "alis_"+database+"_db"),
+								filepath.Join(resultBase, "alis_"+database+".tsv"),
+								"--format-output",
+								columns,
+								"--db-load-mode",
+								"2",
+								"--db-output",
+								"0",
+							},
+							[]string{},
+							1*time.Minute,
+						)
+						if err != nil {
+							errChan <- &JobExecutionError{err}
+							return
+						}
+						if params.Taxonomy {
+							err = execCommandSync(
+								config.Verbose,
+								[]string{
+									config.Paths.Foldseek,
+									"taxonomyreport",
+									foldseekDb,
+									filepath.Join(resultBase, "alis_"+database+"_db"),
+									filepath.Join(resultBase, "alis_"+database+"_report"),
+									"--report-mode",
+									"3",
+								},
+								[]string{},
+								1*time.Minute,
+							)
+							if err != nil {
+								errChan <- &JobExecutionError{err}
+								return
 							}
 						}
-
-						errChan <- nil
 					}
 				}
+
+				errChan <- nil
 			}(index, database)
 		}
 

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -1716,7 +1716,8 @@ rm -rf -- "${BASE}/tmp"
 				outputFile := filepath.Join(resultBase, "alis_"+database)
 				var parameters []string
 				if isBatch {
-					// Batch mode: folddisco writes results to stdout, redirect to file via shell
+					// Batch mode: folddisco writes results to stdout, redirect to file via shell.
+					// Use -t 1 to avoid interleaved output from concurrent queries.
 					parameters = []string{
 						"sh", "-c",
 						config.Paths.FoldDisco + " query" +
@@ -1724,7 +1725,7 @@ rm -rf -- "${BASE}/tmp"
 							" -i " + dbpath +
 							" --top " + top +
 							" --superpose --partial-fit" +
-							" -t " + strconv.Itoa(threads) +
+							" -t 1" +
 							" > " + outputFile,
 					}
 				} else {

--- a/docker-compose/config.json
+++ b/docker-compose/config.json
@@ -15,6 +15,7 @@
         "temporary"    : "/tmp",
         "mmseqs"       : "/usr/local/bin/mmseqs",
         "foldseek"     : "/usr/local/bin/foldseek",
+        "foldseekinterface" : "/usr/local/bin/foldseek-interface",
         "foldmason"    : "/usr/local/bin/foldmason",
         "folddisco"    : "/usr/local/bin/folddisco",
         "foldcomp"    : "/usr/local/bin/foldcomp"

--- a/frontend/History.vue
+++ b/frontend/History.vue
@@ -80,6 +80,9 @@ export default {
                                 case "structuresearch":
                                     obj[v.id] = 'structure'
                                     break;
+                                case "interfacesearch":
+                                    obj[v.id] = 'interface'
+                                    break;
                                 case "complexsearch":
                                     obj[v.id] = 'complex'
                                     break;

--- a/frontend/HistoryAvatar.vue
+++ b/frontend/HistoryAvatar.vue
@@ -32,6 +32,7 @@ export default {
                 case 'complex': return this.$MDI.Multimer
                 case 'msa': return this.$MDI.Wall
                 case 'motif': return this.$MDI.Motif
+                case 'interface': return this.$MDI.Interface
                 default: return this.$MDI.HelpCircleOutline
             }
         }

--- a/frontend/NameField.vue
+++ b/frontend/NameField.vue
@@ -135,14 +135,6 @@ small.ticket {
     margin-right: 4px;
 }
 
-/* @media print, screen and (max-width: 599px) {
-    small.ticket {
-        display: inline-block;
-        line-height: 0.9;
-    }
-} */
-
-/* --- 설정 변수 --- */
 .custom-field-container {
     --primary-color: #fff;
     --error-color: #ff5252;

--- a/frontend/NavigationButton.vue
+++ b/frontend/NavigationButton.vue
@@ -65,10 +65,15 @@ export default {
     tabOffset: {
       type: Number,
       default: 140
+    },
+    hasMoreClusters: {
+      type: Boolean,
+      default: false
     }
   },
   emits: [
-    'needUpdate'
+    'needUpdate',
+    'needRenderNext'
   ],
   watch: {
     scrollOffsetArr: {
@@ -125,7 +130,12 @@ export default {
 
         // scrollNext behavior
         if (currIdx == this.scrollOffsetArr?.length-1 || endOfPage) {
-            this.enableScrollNext = false
+            if (this.hasMoreClusters) {
+                this.enableScrollNext = true
+                this.scrollNextTarget = Infinity
+            } else {
+                this.enableScrollNext = false
+            }
         } else {
             this.enableScrollNext = true
             this.scrollNextTarget = this.scrollOffsetArr?.[currIdx+1] - this.tabOffset
@@ -144,6 +154,10 @@ export default {
         }
     },
     goTo(target) {
+      if (target === Infinity) {
+        this.$emit('needRenderNext')
+        return
+      }
       window.scrollTo({
         top: target,
         left: 0,

--- a/frontend/ResultFoldDisco.vue
+++ b/frontend/ResultFoldDisco.vue
@@ -84,17 +84,36 @@
                         :color="selectedDatabases > 0 ? hits.results[selectedDatabases - 1].color : null"
                         center-active
                         grow
-                        v-model="tabModel"
+                        v-model="selectedDatabases"
                         show-arrows
                         @change="handleChangeDatabase()"
                         v-if="hits.results.length > 1"
                         >
-                            <!-- <v-tab>All databases</v-tab> -->
+                            <v-tab>Summary</v-tab>
                             <v-tab v-for="entry in hits.results" :key="entry.db">{{ entry.db.replaceAll(/_folddisco$/g, '') }} ({{ entry.alignments ? Object.values(entry.alignments).length : 0 }})</v-tab>
                         </v-tabs>
                     </v-sheet>
+                    <TopHits
+                        v-if="hits && hits.results && hits.results.length > 1"
+                        v-show="selectedDatabases == 0"
+                        :hits="hits" :mode="2"
+                        @jumpTo="i => selectedDatabases = i+1"
+                    />
+                    <keep-alive>
+                        <Top100Folddisco
+                            v-if="hits && hits.results && hits.results.length > 1 && selectedDatabases == 0"
+                            ref="top100" :hits="hits" :alignment="alignment" :selectedStates="selectedStates"
+                            :selectedCounts="selectedCounts" :selectUpperbound="selectUpperbound"
+                            @showAlignment="(o, db, e) => showAlignment(o, db, e)"
+                            @toggleSelection="(db, i, v) => handleToggleSelection(db, i, v, true)"
+                            @bulkToggle="(a, v) => handleBulkToggleFromTop100(a, v)"
+                            @forwardDropdown="(e, h) => forwardDropdown(e, h)"
+                            @clearAll="clearAllEntries" @jumpTo="i => selectedDatabases = i+1"
+                        />
+                    </keep-alive>
                     <ResultFoldDiscoDB v-for="(entry, entryidx) in hits.results" :key="entry.db"
-                        v-if="selectedDatabases == 0 || (entryidx + 1) == selectedDatabases"
+                        :ref="'dbComponent' + entryidx"
+                        v-if="(entryidx + 1) == selectedDatabases"
                         :entryidx="entryidx" :entry="entry" :toggleSourceDb="toggleSourceDb"
                         :selectedStates="selectedStates[entryidx]" :selectedCounts="selectedCountPerDb[entryidx]"
                         :totalSelectedCounts="selectedCounts" :selectUpperbound="selectUpperbound" :alignment="alignment"
@@ -105,6 +124,7 @@
                         @toggleSelection="(i, v) => handleToggleSelection(entryidx, i, v)"
                         @bulkToggle="(a, v) => handleBulkToggle(entryidx, a, v)"
                         @updateScroll="() => updateScrollOffsetArr()"
+                        @clusterInfo="(info) => handleClusterInfo(entryidx, info)"
                     ></ResultFoldDiscoDB>
                 </template>
                 </panel>
@@ -126,7 +146,9 @@
                 <NavigationButton :selectedDatabases="selectedDatabases"
                     :scrollOffsetArr="scrollOffsetArr"
                     :tabOffset="tabOffset"
+                    :hasMoreClusters="hasMoreClusters"
                     @needUpdate="updateScrollOffsetArr"
+                    @needRenderNext="handleNeedRenderNext"
                 ></NavigationButton>
             </v-flex>
         </v-layout>
@@ -169,6 +191,8 @@ import NavigationButton from './NavigationButton.vue';
 import ResultFoldDiscoDB from './ResultFoldDiscoDB.vue';
 import SelectToSendPanel from './SelectToSendPanel.vue';
 import NameField from './NameField.vue';
+import TopHits from './TopHits.vue';
+import Top100Folddisco from './Top100Folddisco.vue';
 
 function getAbsOffsetTop($el) {
     var sum = 0;
@@ -183,7 +207,15 @@ function getAbsOffsetTop($el) {
 export default {
     name: 'ResultFoldDisco',
     tool: 'folddisco',
-    components: { Panel, StructureViewerMotif, NavigationButton, ResultFoldDiscoDB, SelectToSendPanel, NameField },
+    components: { Panel, 
+        StructureViewerMotif, 
+        NavigationButton, 
+        ResultFoldDiscoDB, 
+        SelectToSendPanel, 
+        NameField, 
+        TopHits,
+        Top100Folddisco,
+    },
     // components: { ResultView },
     mixins: [ ResultMixin, ResultSankeyMixin ],
     data() {
@@ -205,11 +237,12 @@ export default {
             toggleSourceDb: "",
             dbToIdx: null,
             selectUpperbound: 100,
-            selectedStates: {},
+            selectedStates: null,
             selectedCounts: 0,
-            selectedCountPerDb: {},
+            selectedCountPerDb: null,
             selectedSets: new Set(),
             scrollOffsetArr: [],
+            clusterInfoPerDb: {},
         }
     },
     created() {
@@ -273,19 +306,18 @@ export default {
             }
             return dbGaps;
         },
-        tabModel: {
-            get() {
-            return this.selectedDatabases - 1;
-            },
-            set(val) {
-            this.selectedDatabases = val + 1;
-            }
-        },
         tabOffset() {
             let addend = this.hits?.results?.length == 1 ? 92 : 140
             let sheetHeight = this.$vuetify.breakpoint.xsOnly ? 356 : this.$vuetify.breakpoint.mdAndDown ? 304 : 180
             let colheadHeight = 32
             return addend + sheetHeight + colheadHeight
+        },
+        hasMoreClusters() {
+            for (const key in this.clusterInfoPerDb) {
+                const info = this.clusterInfoPerDb[key]
+                if (info.totalClusterCount > info.renderedClusterCount) return true
+            }
+            return false
         }
     },
     mounted() {
@@ -358,6 +390,7 @@ export default {
                             this.updateScrollOffsetArr()
                         }, 0)
                     })
+                    this.selectedDatabases = n.results.length == 1 ? 1 : 0
                 }
             },
             immediate: false,
@@ -387,7 +420,7 @@ export default {
         },
         async getTargetPdb(item, db) {
             let target = item.dbkey;
-            if (db.startsWith("pdb_")) {
+            if (db.startsWith("pdb")) {
                 target = item.target;
             }
             const re = "api/result/folddisco/" + this.$route.params.ticket + '?database=' + db +'&id=' + target;
@@ -397,9 +430,9 @@ export default {
                 try {
                     const request = await this.$axios.get(re, {
                         headers: {
-                            'Cache-Control': 'no-cache, no-store, must-revalidate',
-                            'Pragma': 'no-cache',
-                            'Expires': '0',
+                            // 'Cache-Control': 'no-cache, no-store, must-revalidate',
+                            // 'Pragma': 'no-cache',
+                            // 'Expires': '0',
                             'Accept': 'text/plain',
                         },
                         transformResponse: [(d) => d],
@@ -436,7 +469,7 @@ export default {
         handleChangeDatabase() {
             this.closeAlignment();
         },
-        handleToggleSelection(db, idx, value) {
+        handleToggleSelection(db, idx, value, fromTop100=false) {
             if (!this.selectedStates || !this.selectedStates[db]
                 || this.selectedCounts > this.selectUpperbound && value) {
                 return
@@ -449,21 +482,36 @@ export default {
             if (this.selectedStates[db][idx] != value) {
                 // Does it really reflect changes?
                 this.selectedStates[db][idx] = value
-                let el = document.getElementById(id)
-                if (el) {
-                    el.classList.toggle('selected', value)
+
+                if (fromTop100) {
+                    document.getElementById('top.' + id)?.classList.toggle('selected', value)                    
+                } else {
+                    document.getElementById(id)?.classList.toggle('selected', value)
                 }
+                
+                
                 const newVal = this.selectedCountPerDb[db] + deltaUnit
                 this.selectedCountPerDb[db] = newVal
                 this.selectedCounts += deltaUnit
                 toCall(id)
                 
                 // update select-all button state
-                const targetDbLength = this.selectedStates[db].length
-                el = document.getElementById(db + '#select-all')
-                if (el) {
-                    el.classList.toggle('any-selected', newVal > 0)
-                    el.classList.toggle('all-selected', newVal == targetDbLength)
+                if (!fromTop100) {
+                    const targetDbLength = this.selectedStates[db].length
+                    let el = document.getElementById(db + '#select-all')
+                    if (el) {
+                        el.classList.toggle('any-selected', newVal > 0)
+                        el.classList.toggle('all-selected', newVal == targetDbLength)
+                    }
+                } else {
+                    const length = this.$refs.top100.entryLength
+                    const newValTop = this.$refs.top100.selectedTopEntries + deltaUnit
+                    const selectAllButton = document.getElementById('top#select-all')
+                    if (selectAllButton) {
+                        selectAllButton.classList.toggle('any-selected', newValTop > 0)
+                        selectAllButton.classList.toggle('all-selected', newValTop == length)
+                    }
+                    this.$refs.top100.selectedTopEntries = newValTop
                 }
             }
         },
@@ -485,10 +533,8 @@ export default {
                 }
                 if (this.selectedStates[db][i] != value) {
                     let id = db + '#' + i.toString()
-                    let el = document.getElementById(id)
-                    if (el) {
-                        el.classList.toggle('selected', value)
-                    }
+                    document.getElementById(id)?.classList.toggle('selected', value)
+
                     this.selectedStates[db][i] = value
                     toCall(id)
                     delta += deltaUnit
@@ -505,6 +551,54 @@ export default {
                 const dbLength = Number(selectAllButton.getAttribute('length'))
                 selectAllButton.classList.toggle('any-selected', newVal > 0)
                 selectAllButton.classList.toggle('all-selected', newVal == dbLength)
+            }
+        },
+        handleBulkToggleFromTop100(indices, value) {
+            // This method is called by Top100 component only
+
+            if (!this.selectedStates 
+                || this.selectedCounts > this.selectUpperbound && value) {
+                return
+            }
+
+            let delta = 0
+            let deltaPerDb = Object.fromEntries(Object.keys(this.selectedStates).map(k => [k, 0]))
+            const deltaUnit = value ? 1 : -1
+            const deltaUpperbound = this.selectUpperbound - this.selectedCounts
+            const toCall = value ? this.selectedSets.add.bind(this.selectedSets) : 
+                this.selectedSets.delete.bind(this.selectedSets)
+            let dbSet = new Set()
+            
+            for (const idx of indices) {
+                if (value && delta >= deltaUpperbound) {
+                    break;
+                }
+                let [db, i] = idx.split("#")
+                dbSet.add(db)
+
+                if (this.selectedStates[db][i] != value) {
+                    document.getElementById('top.' + idx)?.classList.toggle('selected', value)
+                    this.selectedStates[db][i] = value
+                    toCall(idx)
+                    delta += deltaUnit
+                    deltaPerDb[db] += deltaUnit
+                }
+            }
+            
+            this.selectedCounts += delta
+            for (let db of dbSet) {
+                this.selectedCountPerDb[db] += delta
+            }
+            
+            const length = this.$refs.top100.entryLength
+            const newVal = this.$refs.top100.selectedTopEntries + delta
+            this.$refs.top100.selectedTopEntries = newVal
+
+            // update select-all button state
+            const selectAllButton = document.getElementById('top#select-all')
+            if (selectAllButton) {
+                selectAllButton.classList.toggle('any-selected', newVal > 0)
+                selectAllButton.classList.toggle('all-selected', newVal == length)
             }
         },
         updateToggleSourceDb(db) {
@@ -531,6 +625,11 @@ export default {
                     el.classList.toggle('any-selected', false)
                     el.classList.toggle('all-selected', false)
                 }
+            }
+            el = document.getElementById('top#select-all')
+            if (el) {
+                el.classList.toggle('any-selected', false)
+                el.classList.toggle('all-selected', false)
             }
             
             // update selected states manually
@@ -661,6 +760,36 @@ export default {
             const arr = document.querySelectorAll('[class^="result-entry-"]')
             const offsetArr = [...arr].map(n => Math.ceil(n.getBoundingClientRect().top + window.scrollY))
             this.scrollOffsetArr = offsetArr
+        },
+        handleClusterInfo(entryidx, info) {
+            this.$set(this.clusterInfoPerDb, entryidx, info)
+        },
+        async handleNeedRenderNext() {
+            // Find the first child component that has unrendered clusters
+            const results = this.hits?.results
+            if (!results) return
+            for (let i = 0; i < results.length; i++) {
+                if (this.selectedDatabases != 0 && (i + 1) != this.selectedDatabases) continue
+                const refs = this.$refs['dbComponent' + i]
+                const comp = Array.isArray(refs) ? refs[0] : refs
+                if (!comp) continue
+                const info = this.clusterInfoPerDb[i]
+                if (!info || info.totalClusterCount <= info.renderedClusterCount) continue
+                // Find the next unrendered cluster key
+                const nextKey = comp.clusterKeys[comp.renderedClusterKeys.length]
+                if (!nextKey) continue
+                await comp.renderUpToCluster(nextKey)
+                this.$nextTick(() => {
+                    this.updateScrollOffsetArr()
+                    // Scroll to the newly rendered cluster
+                    const el = document.querySelector('.result-entry-' + i + nextKey)
+                    if (el) {
+                        const top = Math.ceil(el.getBoundingClientRect().top + window.scrollY) - this.tabOffset
+                        window.scrollTo({ top, left: 0, behavior: 'smooth' })
+                    }
+                })
+                return
+            }
         }
     },
 };

--- a/frontend/ResultFoldDiscoDB.vue
+++ b/frontend/ResultFoldDiscoDB.vue
@@ -229,7 +229,7 @@
                 </tr>
             </thead>
             <tbody><tr aria-hidden="true" style="height: 8px"></tr></tbody>
-            <tbody v-for="(clu, key) in sortedIndices">
+            <tbody v-for="(clu, key) in visibleSortedIndices">
                 {{ void(clusterShown = false) }}
                 <template v-for="(groupidx, sortIdx) in clu" >
                     <tr v-if="clusters[key].length != entryLength 
@@ -303,6 +303,16 @@
                     </tr>
                 </template>
             </tbody>
+            <tbody v-if="renderLimit < totalSortedCount" ref="sentinel">
+                <tr aria-hidden="true" style="height: 1px"></tr>
+            </tbody>
+            <tbody v-if="renderLimit < totalSortedCount">
+                <tr>
+                    <td :colspan="fullColSpan" style="text-align: center; padding: 8px; color: #888;">
+                        Showing {{ totalVisibleCount }} of {{ totalSortedCount }} hits
+                    </td>
+                </tr>
+            </tbody>
         </table>
     </div>
 </template>
@@ -330,7 +340,11 @@ export default {
             gapFilter: "",
             visibleCluster: {1 : true},
             multipleSelectionEnabled: false,
+            renderLimit: 100,
         }
+    },
+    created() {
+        this.BATCH_SIZE = 100;
     },
     props: {
         entryidx: {
@@ -381,7 +395,9 @@ export default {
                 this.toggleSourceKey = ""
                 this.toggleSourceIdx = -1
                 this.toggleSourceValue = true
+                this.renderLimit = this.BATCH_SIZE
                 this.$nextTick(() => {
+                    this.setupObserver()
                     setTimeout(() => {
                         this.updateVisibility()
                     }, 0)
@@ -401,20 +417,33 @@ export default {
             if (n && this.visibilityTable.length == 0) {
                 this.visibilityTable = Array(this.entryLength).fill(true)
             }
+            if (n) {
+                this.$nextTick(() => { this.setupObserver() })
+            }
         },
         gapFilter(n, o) {
+            this.renderLimit = this.BATCH_SIZE
             this.$nextTick(() => {
+                this.setupObserver()
                 setTimeout(() => {
                     this.updateVisibility()
                 }, 0)
             })
         },
         clusters(n, o) {
+            this.renderLimit = this.BATCH_SIZE
             this.$nextTick(() => {
+                this.setupObserver()
                 setTimeout(() => {
                     this.updateVisibility()
                     this.$emit('updateScroll')
                 }, 0)
+            })
+        },
+        renderedClusterKeys(n, o) {
+            this.$emit('clusterInfo', {
+                totalClusterCount: this.clusterKeys.length,
+                renderedClusterCount: n.length,
             })
         },
     },
@@ -431,6 +460,13 @@ export default {
 
         if (this.$route.query.d2m && this.$route.query.d2m == 1) {
             this.multipleSelectionEnabled = true
+        }
+        this.setupObserver()
+    },
+    beforeDestroy() {
+        if (this._observer) {
+            this._observer.disconnect()
+            this._observer = null
         }
     },
     computed: {
@@ -452,13 +488,54 @@ export default {
         sortedIndices() {
             if (!this.clusters) return this.clusters
 
-            let copiedArrs = structuredClone(this.clusters)
+            let copiedArrs = Object.fromEntries(Object.entries(this.clusters).map(([k, v]) => [k, [...v]]))
 
             for (let key in copiedArrs) {
                 copiedArrs[key].sort(this.comparator)
             }
 
             return copiedArrs
+        },
+        visibleSortedIndices() {
+            if (!this.sortedIndices) return this.sortedIndices
+            let count = 0
+            const result = {}
+            for (const key in this.sortedIndices) {
+                const clu = this.sortedIndices[key]
+                if (count >= this.renderLimit) break
+                const remaining = this.renderLimit - count
+                if (clu.length <= remaining) {
+                    result[key] = clu
+                    count += clu.length
+                } else {
+                    result[key] = clu.slice(0, remaining)
+                    count += remaining
+                }
+            }
+            return result
+        },
+        totalSortedCount() {
+            if (!this.sortedIndices) return 0
+            let count = 0
+            for (const key in this.sortedIndices) {
+                count += this.sortedIndices[key].length
+            }
+            return count
+        },
+        totalVisibleCount() {
+            let count = 0
+            for (const key in this.visibleSortedIndices) {
+                count += this.visibleSortedIndices[key].length
+            }
+            return count
+        },
+        clusterKeys() {
+            if (!this.sortedIndices) return []
+            return Object.keys(this.sortedIndices)
+        },
+        renderedClusterKeys() {
+            if (!this.visibleSortedIndices) return []
+            return Object.keys(this.visibleSortedIndices)
         },
         comparator() {
             let comp = () => {}
@@ -561,40 +638,99 @@ export default {
                     return 3 + offset
                 }
             }
+        },
+        fullColSpan() {
+            let defaultVal = 7
+            let desc = this.entry.hasDescription ? 1 : 0
+            let tax = this.entry.hasTaxonomy ? 1 : 0
+            return defaultVal + desc + tax
         }
     },
     methods: {
+        setupObserver() {
+            if (this._observer) {
+                this._observer.disconnect()
+            }
+            this._observer = new IntersectionObserver((entries) => {
+                if (entries[0].isIntersecting) {
+                    this.loadMore()
+                }
+            })
+            this.$nextTick(() => {
+                if (this.$refs.sentinel) {
+                    this._observer.observe(this.$refs.sentinel)
+                }
+            })
+        },
+        loadMore() {
+            if (this.renderLimit >= this.totalSortedCount) return
+            const oldLimit = this.renderLimit
+            this.renderLimit += this.BATCH_SIZE
+            this.$nextTick(() => {
+                this.reflectSelectionState()
+                this.applyVisibilityToNewRows(oldLimit)
+                if (this.$refs.sentinel && this._observer) {
+                    this._observer.disconnect()
+                    this._observer.observe(this.$refs.sentinel)
+                }
+            })
+        },
+        applyVisibilityToNewRows(oldLimit) {
+            if (!this.isTaxAvailable && !this.isGapFilterAvailable) return
+            let count = 0
+            for (const key in this.visibleSortedIndices) {
+                for (const groupidx of this.visibleSortedIndices[key]) {
+                    count++
+                    if (count <= oldLimit) continue
+                    const id = this.entryidx + "#" + String(groupidx)
+                    const el = document.getElementById(id)
+                    if (el) {
+                        el.classList.toggle('invisible', !this.visibilityTable[groupidx])
+                    }
+                }
+            }
+        },
+        renderUpToCluster(clusterKey) {
+            if (!this.sortedIndices) return Promise.resolve()
+            let count = 0
+            for (const key in this.sortedIndices) {
+                count += this.sortedIndices[key].length
+                if (key == clusterKey) break
+            }
+            if (count > this.renderLimit) {
+                this.renderLimit = Math.ceil(count / this.BATCH_SIZE) * this.BATCH_SIZE
+            }
+            return this.$nextTick()
+        },
         log(a) {
             console.log(a)
             return a
         },
         updateVisibility() {
             if (!this.entry) return
- 
-            let el = undefined
-            let id = ''
+
+            // Set visibility data for ALL entries
             if (!this.isTaxAvailable && !this.isGapFilterAvailable) {
                 this.visibilityTable = Array(this.entryLength).fill(true)
-                for (let i = 0; i < this.entryLength; i++) {
-                    id = this.entryidx + "#" + String(i)
-                    el = document.getElementById(id)
-                    if (el) {
-                        el.classList.toggle('invisible', false)
-                    }
-                }
             } else {
                 for (let i = 0; i < this.entryLength; i++) {
-                    let target = this.isGroupVisible(this.entry.alignments[i]) 
+                    this.visibilityTable[i] = this.isGroupVisible(this.entry.alignments[i])
                         && this.isItemVisible(this.entry.alignments[i][0])
-                    this.visibilityTable[i] = target
-                    id = this.entryidx + "#" + String(i)
-                    el = document.getElementById(id)
+                }
+            }
+
+            // Toggle DOM only for rendered entries
+            for (const key in this.visibleSortedIndices) {
+                for (const groupidx of this.visibleSortedIndices[key]) {
+                    let id = this.entryidx + "#" + String(groupidx)
+                    let el = document.getElementById(id)
                     if (el) {
-                        el.classList.toggle('invisible', !target)
+                        el.classList.toggle('invisible', !this.visibilityTable[groupidx])
                     }
                 }
             }
 
+            // Compute cluster visibility from ALL clusters (data level)
             const visibility = Object.keys(this.clusters).reduce((acc, key) => {
                 acc[key] = false;
                 return acc;
@@ -752,12 +888,15 @@ export default {
         reflectSelectionState() {
             let value = false
             let id = ""
-            for (let i = 0; i < this.entryLength; i++) {
-                value = this.selectedStates[i]
-                id = this.entryidx + "#" + String(i)
-                let el = document.getElementById(id)
-                if (el) {
-                    el.classList.toggle('selected', value ? true : false)
+            // Only iterate rendered entries
+            for (const key in this.visibleSortedIndices) {
+                for (const groupidx of this.visibleSortedIndices[key]) {
+                    value = this.selectedStates[groupidx]
+                    id = this.entryidx + "#" + String(groupidx)
+                    let el = document.getElementById(id)
+                    if (el) {
+                        el.classList.toggle('selected', value ? true : false)
+                    }
                 }
             }
             let select_all_button = document.getElementById(this.entryidx + '#select-all')
@@ -789,7 +928,14 @@ export default {
             this.toggleSourceKey = ""
             this.toggleSourceIdx = -1
             this.toggleTargetValue = true
+            this.renderLimit = this.BATCH_SIZE
             this.$nextTick(() => {
+                window.scrollTo({
+                    top: 0,
+                    left: 0,
+                    behavior: 'smooth',
+                })
+                this.setupObserver()
                 setTimeout(() => {
                     this.reflectSelectionState()
                 }, 0)
@@ -1095,6 +1241,10 @@ th.sort-criterion.sort-selected {
             text-overflow: ellipsis;
             white-space: nowrap;
         }
+        th {
+            // overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 }
 
@@ -1143,6 +1293,8 @@ th.sort-criterion.sort-selected {
             position: relative;
             display: block;
             padding: 2em;
+            margin-left: 2em;
+            margin-right: 2em;
             cursor: pointer;
         }
 

--- a/frontend/ResultMixin.vue
+++ b/frontend/ResultMixin.vue
@@ -35,45 +35,17 @@ export default {
             for (let result of (__LOCAL__) ? this.currentResult.results : this.hits.results) {
                 result.color = color(result.db ? result.db : 0);
                 let colorHsl = rgb2hsl(result.color);
-                let max = {
-                    score: Number.MIN_VALUE,
-                    idfscore: Number.MIN_VALUE,
-                    // eval: Number.MIN_VALUE,
-                    // prob: Number.MIN_VALUE,
-                    // seqId: Number.MIN_VALUE,
-                    // qStartPos: Number.MIN_VALUE,
-                    // qEndPos: Number.MIN_VALUE,
-                    // qLen: Number.MIN_VALUE,
-                    // dbStartPos: Number.MIN_VALUE,
-                    // dbEndPos: Number.MIN_VALUE,
-                    // dbLen: Number.MIN_VALUE,
-                }
-                let min = {
-                    score: Number.MAX_VALUE,
-                    idfscore: Number.MAX_VALUE,
-                    // eval: Number.MAX_VALUE,
-                    // prob: Number.MAX_VALUE,
-                    // seqId: Number.MAX_VALUE,
-                    // qStartPos: Number.MAX_VALUE,
-                    // qEndPos: Number.MAX_VALUE,
-                    // qLen: Number.MAX_VALUE,
-                    // dbStartPos: Number.MAX_VALUE,
-                    // dbEndPos: Number.MAX_VALUE,
-                    // dbLen: Number.MAX_VALUE,
-                }
+                let maxScore = Number.MIN_VALUE;
+                let minScore = Number.MAX_VALUE;
                 for (let entry of Object.values(result.alignments)) {
                     for (let alignment of entry) {
-                        for (const key in min) {
-                            if (key in alignment) {
-                                min[key] = alignment[key] < min[key] ? alignment[key] : min[key];
-                                max[key] = alignment[key] > max[key] ? alignment[key] : max[key];
-                            }
-                        }
+                        if (alignment.score < minScore) minScore = alignment.score;
+                        if (alignment.score > maxScore) maxScore = alignment.score;
                     }
                 }
                 for (let entry of Object.values(result.alignments)) {
                     for (let alignment of entry) {
-                        let r = lerp(min.score / max.score, 1, alignment.score / max.score);
+                        let r = lerp(minScore / maxScore, 1, alignment.score / maxScore);
                         const luminosity = clamp(colorHsl[2] * Math.pow(0.55, -(1 - r)), 0.1, 0.9);
                         alignment.color = `hsl(${colorHsl[0]}, ${colorHsl[1]*100}%, ${luminosity*100}%)`
                     }

--- a/frontend/ResultView.vue
+++ b/frontend/ResultView.vue
@@ -86,28 +86,47 @@
                         :color="selectedDatabases > 0 ? hits.results[selectedDatabases - 1].color : null"
                         center-active
                         grow
-                        v-model="tabModel"
+                        v-model="selectedDatabases"
                         show-arrows
                         @change="handleChangeDatabase()"
                         v-if="hits.results.length > 1"
                         >
-                        <!-- <v-tab>All databases</v-tab> -->
+                        <v-tab>Summary</v-tab>
                         <v-tab v-for="entry in hits.results" :key="entry.db">{{ entry.db }} ({{ entry.alignments ? Object.values(entry.alignments).length : 0 }})</v-tab>
                     </v-tabs>
                     </v-sheet>
-                <ResultFoldseekDB v-for="(entry, entryidx) in hits.results"  :key="entry.db"
-                    v-if="selectedDatabases == 0 || (entryidx + 1) == selectedDatabases"
-                    :tableMode="tableMode" :entryidx="entryidx" :entry="entry" :toggleSourceDb="toggleSourceDb"
-                    :mode="mode" :selectedStates="selectedStates[entryidx]" :selectedCounts="selectedCountPerDb[entryidx]"
-                    :totalSelectedCounts="selectedCounts" :selectUpperbound="selectUpperbound" :alignment="alignment"
-                    :onlyOne="hits.results.length == 1" :isComplex="isComplex"
-                    @switchTableMode="(n) => switchTableMode(n)" 
-                    @forwardDropdown="(e, h) => forwardDropdown(e, h)"
-                    @showAlignment="(i, e) => showAlignment(i, entry.db, e)"
-                    @updateToggleSource="(db) => updateToggleSourceDb(db)"
-                    @toggleSelection="(i, v) => handleToggleSelection(entryidx, i, v)"
-                    @bulkToggle="(a, v) => handleBulkToggle(entryidx, a, v)"
-                ></ResultFoldseekDB>
+                    <TopHits
+                        v-if="hits && hits.results && hits.results.length > 1"
+                        v-show="selectedDatabases == 0"
+                        :hits="hits" :mode="isComplex ? 1 : 0" :alignMode="mode"
+                        @jumpTo="i => selectedDatabases = i+1" 
+                    />
+                    <keep-alive>
+                        <Top100Foldseek
+                            v-if="hits && hits.results && hits.results.length > 1 && selectedDatabases == 0" ref="top100"
+                            :hits="hits" :mode="mode" :isComplex="isComplex" :tableMode="tableMode" :alignment="alignment"
+                            :selectedStates="selectedStates" :selectedCounts="selectedCounts" :selectUpperbound="selectUpperbound"
+                            @switchTableMode="(n) => switchTableMode(n)" 
+                            @showAlignment="(o, db, e) => showAlignment(o, db, e)"
+                            @toggleSelection="(db, i, v) => handleToggleSelection(db, i, v, true)"
+                            @bulkToggle="(a, v) => handleBulkToggleFromTop100(a, v)"
+                            @forwardDropdown="(e, h) => forwardDropdown(e, h)"
+                            @jumpTo="i => selectedDatabases = i+1" 
+                        />
+                    </keep-alive>
+                    <ResultFoldseekDB v-for="(entry, entryidx) in hits.results"  :key="entry.db"
+                        v-if="(entryidx + 1) == selectedDatabases"
+                        :tableMode="tableMode" :entryidx="entryidx" :entry="entry" :toggleSourceDb="toggleSourceDb"
+                        :mode="mode" :selectedStates="selectedStates[entryidx]" :selectedCounts="selectedCountPerDb[entryidx]"
+                        :totalSelectedCounts="selectedCounts" :selectUpperbound="selectUpperbound" :alignment="alignment"
+                        :onlyOne="hits.results.length == 1" :isComplex="isComplex"
+                        @switchTableMode="(n) => switchTableMode(n)" 
+                        @forwardDropdown="(e, h) => forwardDropdown(e, h)"
+                        @showAlignment="(i, e) => showAlignment(i, entry.db, e)"
+                        @updateToggleSource="(db) => updateToggleSourceDb(db)"
+                        @toggleSelection="(i, v) => handleToggleSelection(entryidx, i, v)"
+                        @bulkToggle="(a, v) => handleBulkToggle(entryidx, a, v)"
+                    ></ResultFoldseekDB>
                 </template>
                 </panel>
                 <SelectToSendPanel
@@ -170,20 +189,23 @@ import { debounce } from './lib/debounce';
 import ResultFoldseekDB from './ResultFoldseekDB.vue';
 import SelectToSendPanel from './SelectToSendPanel.vue';
 import NameField from './NameField.vue';
+import TopHits from './TopHits.vue';
+import Top100Foldseek from './Top100Foldseek.vue';
 
 export default {
     name: 'ResultView',
     mixins: [ ResultSankeyMixin, AllAtomPredictMixin ],
     components: { Panel, AlignmentPanel, Ruler, 
-        NavigationButton, ResultFoldseekDB, SelectToSendPanel, NameField },
+        NavigationButton, ResultFoldseekDB, SelectToSendPanel, 
+        NameField, TopHits, Top100Foldseek },
     data() {
         return {
             alignment: null,
             activeTarget: null,
             alnBoxOffset: 0,
             selectedDatabases: 0,
-            selectedStates: {},
-            selectedCountsPerDb: {},
+            selectedStates: null,
+            selectedCountsPerDb: null,
             selectedCounts: 0,
             selectedSets: new Set(),
             tableMode: 0,
@@ -261,6 +283,7 @@ export default {
                             this.updateScrollOffsetArr()
                         }, 0)
                     })
+                    this.selectedDatabases = this.onlyOne ? 1 : 0
                 }
             },
             immediate: false,
@@ -312,14 +335,6 @@ export default {
         onlyOne() {
             return this.hits?.results?.length == 1
         },
-        tabModel: {
-            get() {
-            return this.selectedDatabases - 1;
-            },
-            set(val) {
-            this.selectedDatabases = val + 1;
-            }
-        },
     },
     methods: {
         log(args) {
@@ -362,7 +377,7 @@ export default {
         handleChangeDatabase() {
             this.closeAlignment();
         },
-        handleToggleSelection(db, idx, value) {
+        handleToggleSelection(db, idx, value, fromTop100=false) {
             if (!this.selectedStates || !this.selectedStates[db]
                 || this.selectedCounts > this.selectUpperbound && value) {
                 return
@@ -373,23 +388,36 @@ export default {
             const toCall = value ? this.selectedSets.add.bind(this.selectedSets) : 
                 this.selectedSets.delete.bind(this.selectedSets)
             if (this.selectedStates[db][idx] != value) {
-                // Does it really reflect changes?
                 this.selectedStates[db][idx] = value
-                let el = document.getElementById(id)
-                if (el) {
-                    el.classList.toggle('selected', value)
+
+                if (fromTop100) {
+                    document.getElementById('top.' + id)?.classList.toggle('selected', value)
+                } else {
+                    document.getElementById(id)?.classList.toggle('selected', value)
                 }
+
                 const newVal = this.selectedCountPerDb[db] + deltaUnit
                 this.selectedCountPerDb[db] = newVal
                 this.selectedCounts += deltaUnit
                 toCall(id)
                 
                 // update select-all button state
-                const targetDbLength = this.selectedStates[db].length
-                el = document.getElementById(db + '#select-all')
-                if (el) {
-                    el.classList.toggle('any-selected', newVal > 0)
-                    el.classList.toggle('all-selected', newVal == targetDbLength)
+                if (!fromTop100) {
+                    const targetDbLength = this.selectedStates[db].length
+                    let el = document.getElementById(db + '#select-all') 
+                    if (el) {
+                        el.classList.toggle('any-selected', newVal > 0)
+                        el.classList.toggle('all-selected', newVal == targetDbLength)
+                    }
+                } else {
+                    const length = this.$refs.top100.entryLength
+                    const newValTop = this.$refs.top100.selectedTopEntries + deltaUnit
+                    const selectAllButton = document.getElementById('top#select-all')
+                    if (selectAllButton) {
+                        selectAllButton.classList.toggle('any-selected', newValTop > 0)
+                        selectAllButton.classList.toggle('all-selected', newValTop == length)
+                    }
+                    this.$refs.top100.selectedTopEntries = newValTop
                 }
             }
         },
@@ -411,10 +439,8 @@ export default {
                 }
                 if (this.selectedStates[db][i] != value) {
                     let id = db + '#' + i.toString()
-                    let el = document.getElementById(id)
-                    if (el) {
-                        el.classList.toggle('selected', value)
-                    }
+                    document.getElementById(id)?.classList.toggle('selected', value)
+
                     this.selectedStates[db][i] = value
                     toCall(id)
                     delta += deltaUnit
@@ -433,6 +459,54 @@ export default {
                 selectAllButton.classList.toggle('all-selected', newVal == dbLength)
             }
         },
+        handleBulkToggleFromTop100(indices, value) {
+            // This method is called by Top100 component only
+
+            if (!this.selectedStates 
+                || this.selectedCounts > this.selectUpperbound && value) {
+                return
+            }
+
+            let delta = 0
+            let deltaPerDb = Object.fromEntries(Object.keys(this.selectedStates).map(k => [k, 0]))
+            const deltaUnit = value ? 1 : -1
+            const deltaUpperbound = this.selectUpperbound - this.selectedCounts
+            const toCall = value ? this.selectedSets.add.bind(this.selectedSets) : 
+                this.selectedSets.delete.bind(this.selectedSets)
+            let dbSet = new Set()
+            
+            for (const idx of indices) {
+                if (value && delta >= deltaUpperbound) {
+                    break;
+                }
+                let [db, i] = idx.split("#")
+                dbSet.add(db)
+
+                if (this.selectedStates[db][i] != value) {
+                    document.getElementById('top.' + idx)?.classList.toggle('selected', value)
+                    this.selectedStates[db][i] = value
+                    toCall(idx)
+                    delta += deltaUnit
+                    deltaPerDb[db] += deltaUnit
+                }
+            }
+            
+            this.selectedCounts += delta
+            for (let db of dbSet) {
+                this.selectedCountPerDb[db] += delta
+            }
+            
+            const length = this.$refs.top100.entryLength
+            const newVal = this.$refs.top100.selectedTopEntries + delta
+            this.$refs.top100.selectedTopEntries = newVal
+
+            // update select-all button state
+            const selectAllButton = document.getElementById('top#select-all')
+            if (selectAllButton) {
+                selectAllButton.classList.toggle('any-selected', newVal > 0)
+                selectAllButton.classList.toggle('all-selected', newVal == length)
+            }
+        },
         clearAllEntries() {
             if (!this.selectedStates) {
                 return
@@ -449,6 +523,11 @@ export default {
                     el.classList.toggle('any-selected', false)
                     el.classList.toggle('all-selected', false)
                 }
+            }
+            el = document.getElementById("top#select-all")
+            if (el) {
+                el.classList.toggle("any-selected", false)
+                el.classList.toggle("all-selected", false)
             }
             
             // update selected states manually

--- a/frontend/Ruler.vue
+++ b/frontend/Ruler.vue
@@ -1,18 +1,15 @@
-<template>
+<template functional>
     <div class="ruler">
-      <!-- <div class="tick" v-once v-for="(tick, i) in ticks" :key="tick" :style="{ left: tick + '%' }"></div> -->
-      <!-- <div class="tick-label" v-if="label">1</div> -->
-      <!-- <div class="tick-label" v-if="label" style="left: 100%">{{ length }}</div> -->
-      <div class="query" :class="{ reversed : reversed }" :style="{ left: queryLeft + '%', right: queryRight + '%' }">
-        <div class="chevron-start" :style="{ 'background-color': color }"></div>
-        <div class="chevron-mid" :style="{ 'background-color': color }"></div>
-        <div class="chevron-end" :style="{ 'background-color': color }"></div>
+      <div class="query" :class="{ reversed : props.start > props.end }" :style="{ left: ((Math.min(props.start, props.end) - 1) / props.length) * 100 + '%', right: 100 - ((Math.max(props.start, props.end) / props.length) * 100) + '%' }">
+        <div class="chevron-start" :style="{ 'background-color': props.color }"></div>
+        <div class="chevron-mid" :style="{ 'background-color': props.color }"></div>
+        <div class="chevron-end" :style="{ 'background-color': props.color }"></div>
       </div>
-      <div class="tick-label" :style="{ left: queryLeft + '%' }">{{ minStart }}</div>
-      <div class="tick-label" :style="{ right: queryRight + '%', 'margin-left': 0, 'margin-right': '-25px' }">{{ maxEnd }}</div>
+      <div class="tick-label" :style="{ left: ((Math.min(props.start, props.end) - 1) / props.length) * 100 + '%' }">{{ Math.min(props.start, props.end) }}</div>
+      <div class="tick-label" :style="{ right: 100 - ((Math.max(props.start, props.end) / props.length) * 100) + '%', 'margin-left': 0, 'margin-right': '-25px' }">{{ Math.max(props.start, props.end) }}</div>
     </div>
   </template>
-  
+
   <script>
   export default {
     props: {
@@ -21,37 +18,10 @@
       end: Number,
       color: String,
       label: Boolean,
-      tickInterval: {
-        type: Number,
-        default: 10
-      }
     },
-    computed: {
-      minStart() {
-        return Math.min(this.start, this.end);
-      },
-      maxEnd() {
-        return Math.max(this.start, this.end);
-      },
-      reversed() {
-        return this.start > this.end;
-      },
-      queryLeft() {
-        return ((this.minStart - 1) / this.length) * 100;
-      },
-      queryRight() {
-        return 100 - ((this.maxEnd / this.length) * 100);
-      },
-      numTicks() {
-        return 3;
-      },
-      ticks() {
-        return Array.from({ length: this.numTicks + 1 }, (_, i) => i / this.numTicks * 100);
-      }
-    }
   };
   </script>
-  
+
 <style lang="scss" scoped>
 .ruler {
   position: relative;

--- a/frontend/StructureViewerMixin.vue
+++ b/frontend/StructureViewerMixin.vue
@@ -1,5 +1,6 @@
 <script>
 import { Stage } from 'ngl';
+import { wrapLog, recoverLog } from './Utilities';
 
 export default {
     data: () => ({
@@ -21,7 +22,7 @@ export default {
         },
         stageParameters: function() {
             return {
-                log: 'none',
+                log: false,
                 backgroundColor: this.bgColor,
                 transparent: true,
                 ambientIntensity: this.ambientIntensity,
@@ -93,11 +94,15 @@ export default {
             this.stage.viewer.renderer.domElement.addEventListener('mousedown', e => {
                 this.isSpinning = false;
             })
+
+            // To ignore "STAGE LOG ..." things.
+            wrapLog()
         },
         teardownStage() {
             window.removeEventListener('resize', this.handleResize)
             if (!this.stage) return;
-            this.stage.dispose() 
+            this.stage.dispose()
+            recoverLog()
         },
         handleMakeImage() {
             this.makeImage();

--- a/frontend/StructureViewerThumbnail.vue
+++ b/frontend/StructureViewerThumbnail.vue
@@ -1,0 +1,628 @@
+<template>
+<div>
+    <div ref="offscreenContainer" class="offscreen-container">
+        <div ref="viewport" class="offscreen-viewport" :style="{ width: thumbWidth + 'px', height: thumbHeight + 'px' }"></div>
+    </div>
+    <div ref="interactiveContainer"></div>
+</div>
+</template>
+
+<script>
+import { Stage, Selection, ColormakerRegistry, concatStructures, download, } from 'ngl';
+import { mockPDB, makeSubPDB, transformStructure, storeChains, revertChainInfo, wrapLog, recoverLog } from './Utilities.js';
+import { pulchra } from 'pulchra-wasm';
+import { tmalign, parseMatrix as parseTMMatrix } from 'tmalign-wasm';
+
+const getChainName = (name) => {
+    if (/_v[0-9]+$/.test(name)) return 'A';
+    let pos = name.lastIndexOf('_');
+    if (pos != -1) {
+        let match = name.substring(pos + 1);
+        return match.length >= 1 ? match[0] : 'A';
+    }
+    return 'A';
+};
+
+const getAccession = (name) => {
+    if (/_v[0-9]+$/.test(name)) return name;
+    let pos = name.lastIndexOf('_');
+    return pos != -1 ? name.substring(0, pos) : name;
+};
+
+const processPdb = (rawpdb) => {
+    let outpdb = '';
+    let data = '';
+    let ext = 'pdb';
+    outpdb = rawpdb.trimStart();
+    if (outpdb[0] == "#" || outpdb.startsWith("data_")) {
+        ext = 'cif';
+        // NGL doesn't like AF3's _chem_comp entries
+        outpdb = outpdb.replaceAll("_chem_comp.", "_chem_comp_SKIP_HACK.");
+    } else {
+        for (let line of outpdb.split('\n')) {
+            let numCols = Math.max(0, 80 - line.length);
+            let newLine = line + ' '.repeat(numCols) + '\n';
+            data += newLine
+        }
+        outpdb = data;
+    }
+    return [outpdb, ext]
+}
+
+const getMotif = (motif) => {
+    const motifList = new Set(motif.split(','));
+    const motifSele = [];
+    for (let m of motifList) {
+        const chain = m[0];
+        const resno = m.slice(1);
+        motifSele.push(`${resno}:${chain}`);
+    }
+
+    return motifSele.join(" or ");
+}
+
+export default {
+    name: "StructureViewerThumbnail",
+    data() {
+        return {
+            stage: null,
+            isRendering: false,
+            currentQueueIndex: 0,
+            activeId: null,
+            cachedQueryPdb: null,
+            destroyed: false,
+            schemeCounter: 0,
+            isSpinning: false,
+            queuePaused: false,
+            activeTargetEl: null,
+            pulchraFailed: false,
+        }
+    },
+    props: {
+        thumbnailQueue: { type: Array, default: () => [] },
+        activeAlignment: { type: Object, default: null },
+        hits: { type: Object },
+        thumbWidth: { type: Number, default: 286 },
+        thumbHeight: { type: Number, default: 240 },
+        mode: {type: Number, default: 0}, /* 0: Foldseek; 1: Foldseek Multimer; 2: Folddisco */
+    },
+    methods: {
+        bgColor() {
+            return this.$vuetify.theme.dark ? '#1E1E1E' : 'white';
+        },
+
+        initStage() {
+            this.stage = new Stage(this.$refs.viewport, {
+                log: false,
+                backgroundColor: this.bgColor(),
+                transparent: true,
+                quality: 'low',
+                clipNear: -1000,
+                clipFar: 1000,
+                fogFar: 1000,
+                fogNear: -1000,
+                tooltip: false,
+            });
+            this.stage.setSize(this.thumbWidth, this.thumbHeight);
+
+            // To ignore "STAGE LOG ..." things.
+            wrapLog()
+        },
+
+        async getQueryPdb() {
+            if (this.cachedQueryPdb !== null) return this.cachedQueryPdb;
+
+            let queryPdb = "";
+            if (this.$LOCAL) {
+                if (this.hits.queries[0].hasOwnProperty('pdb')) {
+                    queryPdb = JSON.parse(this.hits.queries[0].pdb);
+                } else {
+                    queryPdb = mockPDB(this.hits.queries[0].qCa, this.hits.queries[0].sequence, 'A');
+                }
+            } else if (this.$route.params.ticket.startsWith('user-')) {
+                if (this.hits.queries[0].hasOwnProperty('pdb')) {
+                    queryPdb = JSON.parse(this.hits.queries[0].pdb);
+                } else {
+                    const localData = this.$root.userData[this.$route.params.entry];
+                    queryPdb = mockPDB(localData.queries[0].qCa, localData.queries[0].sequence, 'A');
+                }
+            } else {
+                try {
+                    const request = await this.$axios.get("api/result/" + this.$route.params.ticket + '/query');
+                    queryPdb = request.data;
+                } catch (e) {
+                    queryPdb = "";
+                }
+            }
+
+            this.cachedQueryPdb = queryPdb;
+            return queryPdb;
+        },
+
+        async buildTargetStructure(alignments, db) {
+            if (this.mode < 2) {
+                const targets = [];
+                let renumber = 0;
+                let lastIdx = null;
+                let remoteData = null;
+                let i = 0;
+
+                for (let alignment of alignments) {
+                    const chain = getChainName(alignment.target);
+                    let tSeq = alignment.tSeq;
+                    let tCa = alignment.tCa;
+
+                    if (Number.isInteger(alignment.tCa) && Number.isInteger(alignment.tSeq)) {
+                        const idx = alignment.tCa;
+                        if (idx != lastIdx) {
+                            const ticket = this.$route.params.ticket;
+                            const entry = this.$route.params.entry;
+                            const response = await this.$axios.get(
+                                "api/result/" + ticket + '/' + entry + '?format=brief&index=' + idx + '&database=' + db
+                            );
+                            remoteData = response.data;
+                            lastIdx = idx;
+                        }
+                        tSeq = remoteData[i].tSeq;
+                        tCa = remoteData[i].tCa;
+                        i++;
+                    }
+
+                    if (!tCa) return null;
+
+                    const mock = mockPDB(tCa, tSeq, chain);
+                    let pdb;
+                    try {
+                        pdb = await pulchra(mock);
+                    } catch (e) {
+                        pdb = mock;
+                        this.pulchraFailed = true;
+                    }
+                    if (this.destroyed || !this.stage) return null;
+
+                    const component = await this.stage.loadFile(
+                        new Blob([pdb], { type: 'text/plain' }),
+                        { ext: 'pdb', firstModelOnly: true }
+                    );
+                    component.structure.eachChain(c => { c.chainname = chain; });
+                    component.structure.eachAtom(a => { a.serial = renumber++; });
+                    targets.push(component);
+                }
+
+                if (targets.length === 0) return null;
+
+                const structure = concatStructures(
+                    getAccession(alignments[0].target),
+                    ...targets.map(t => t.structure)
+                );
+                return this.stage.addComponentFromObject(structure);
+            } else {
+                let item = alignments[0]
+                if (!item) {
+                   return null
+                }
+
+                let target = item.dbkey
+                if (db.startsWith('pdb')) {
+                    target = item.target                    
+                }
+
+                const re = "api/result/folddisco/" + this.$route.params.ticket + '?database=' + db +'&id=' + target;
+                const request = await this.$axios.get(re, {
+                    headers: {
+                        'Accept': 'text/plain',
+                    },
+                    transformResponse: [(d) => d],
+                });
+                let [ targetPdb, ext ] = processPdb(request.data)
+                return await this.stage.loadFile(new Blob([targetPdb], {type: 'text/plain'}), { ext: ext, firstModelOnly: true, name: 'targetStructure'})
+            }
+        },
+
+        async loadQueryStructure(rawQueryPdb) {
+            if (!rawQueryPdb) return null;
+
+            let [ queryPdb, ext ] = processPdb(rawQueryPdb)
+
+            let query = await this.stage.loadFile(
+                new Blob([queryPdb], { type: 'text/plain' }),
+                { ext: ext, firstModelOnly: true }
+            );
+            if (this.destroyed || !this.stage) return null;
+
+            if (query && query.structure.getAtomProxy().isCg()) {
+                try {
+                    let pdbText = queryPdb;
+                    if (ext == "cif") {
+                        const { PdbWriter } = await import('ngl');
+                        let pw = new PdbWriter(query.structure, { renumberSerial: false });
+                        pdbText = pw.getData().split('\n').filter(line => line.startsWith('ATOM')).join('\n');
+                    }
+                    const chains = storeChains(pdbText);
+                    let pulchraResult = await pulchra(pdbText);
+                    pulchraResult = revertChainInfo(pulchraResult, chains);
+                    if (this.destroyed || !this.stage) return null;
+                    this.stage.removeComponent(query);
+                    query = await this.stage.loadFile(
+                        new Blob([pulchraResult], { type: 'text/plain' }),
+                        { ext: 'pdb', firstModelOnly: true }
+                    );
+                } catch (e) {
+                    // Keep original CA-only query
+                }
+            }
+
+            return query;
+        },
+
+        async superposeStructures(queryComp, targetComp, alignments) {
+            if (!queryComp || !targetComp) return;
+
+            if (alignments[0].hasOwnProperty("complexu") && alignments[0].hasOwnProperty("complext")) {
+                const t = alignments[0].complext.split(',').map(x => parseFloat(x));
+                let u = alignments[0].complexu.split(',').map(x => parseFloat(x));
+                u = [
+                    [u[0], u[1], u[2]],
+                    [u[3], u[4], u[5]],
+                    [u[6], u[7], u[8]],
+                ];
+                transformStructure(targetComp.structure, t, u);
+            } else if (alignments[0].hasOwnProperty("tmat") && alignments[0].hasOwnProperty("umat")) {
+                const t = alignments[0].tmat.split(',').map(x => parseFloat(x));
+                let u = alignments[0].umat.split(',').map(x => parseFloat(x));
+                u = [
+                    [u[0], u[1], u[2]],
+                    [u[3], u[4], u[5]],
+                    [u[6], u[7], u[8]],
+                ];
+                transformStructure(targetComp.structure, t, u);
+            } else {
+                const querySele = alignments.map(
+                    a => `${a.qStartPos}-${a.qEndPos}:${getChainName(a.query)}`
+                ).join(" or ");
+                const targetSele = alignments.map(
+                    a => `${a.dbStartPos}-${a.dbEndPos}:${getChainName(a.target)}`
+                ).join(" or ");
+
+                let qSubPdb = makeSubPDB(queryComp.structure, querySele);
+                let tSubPdb = makeSubPDB(targetComp.structure, targetSele);
+                let alnFasta = `>target\n${alignments[0].dbAln}\n\n>query\n${alignments[0].qAln}`;
+
+                const tm = await tmalign(tSubPdb, qSubPdb, alnFasta);
+                if (this.destroyed || !this.stage) return;
+                let { t, u } = parseTMMatrix(tm.matrix);
+                transformStructure(targetComp.structure, t, u);
+            }
+        },
+
+        addRepresentations(queryComp, targetComp, alignments) {
+            const id = this.schemeCounter++;
+
+            let selections_q = this.mode < 2 
+                ? alignments.map(
+                    a => `${a.qStartPos}-${a.qEndPos}:${getChainName(a.query)}`
+                ).join(" or ")
+                : getMotif(alignments[0].queryresidues)
+            let selections_t = this.mode < 2
+                ? alignments.map(
+                    a => `${a.dbStartPos}-${a.dbEndPos}:${getChainName(a.target)}`
+                ).join(" or ")
+                : getMotif(alignments[0].targetresidues)
+
+            const qSchemeName = `_thumbQuery_${id}`;
+            const tSchemeName = `_thumbTarget_${id}`;
+
+            if (ColormakerRegistry.hasScheme(qSchemeName)) {
+                ColormakerRegistry.removeScheme(qSchemeName);
+            }
+            if (ColormakerRegistry.hasScheme(tSchemeName)) {
+                ColormakerRegistry.removeScheme(tSchemeName);
+            }
+
+            const querySchemeId = ColormakerRegistry.addSelectionScheme([
+                ["#1E88E5", selections_q],
+                ["#A5CFF5", "*"],
+            ], qSchemeName);
+
+            const targetSchemeId = ColormakerRegistry.addSelectionScheme([
+                ["#FFC107", selections_t],
+                ["#FFE699", "*"],
+            ], tSchemeName);
+
+            const repr = this.mode < 2 
+                ? ( this.pulchraFailed ? 'backbone' : 'cartoon' ) 
+                : 'licorice'
+
+            if (queryComp) {
+                queryComp.addRepresentation(repr, {
+                    sele: this.mode < 2 ? "" : selections_q,
+                    color: querySchemeId,
+                    smoothSheet: true,
+                });
+                queryComp.autoView(selections_q, 0);
+            }
+
+            targetComp.addRepresentation(repr, {
+                sele: this.mode < 2 ? "" : selections_t,
+                color: targetSchemeId,
+                smoothSheet: true,
+            });
+        },
+
+        async captureThumbnail(id) {
+            await new Promise(resolve => requestAnimationFrame(resolve));
+            if (this.destroyed || !this.stage) return;
+
+            const blob = await this.stage.makeImage({
+                trim: false,
+                factor: 2,
+                antialias: true,
+                transparent: true,
+            });
+            if (this.destroyed) return;
+
+            this.$emit('thumbnail-ready', { id, blob });
+        },
+
+        clearStage() {
+            if (!this.stage) return;
+            this.stage.removeAllComponents();
+            this.pulchraFailed = false;
+        },
+
+        async activateViewer(id, alignments, targetEl) {
+            if (this.activeId === id) return;
+            this.clearStage();
+            this.queuePaused = true;
+            this.activeId = id;
+            this.activeTargetEl = targetEl;
+
+            // Move canvas into the card's viewer slot
+            const viewportEl = this.$refs.viewport;
+            targetEl.appendChild(viewportEl);
+            this.stage.setParameters({ quality: 'high', backgroundColor: this.bgColor() });
+            viewportEl.style.width = '100%';
+            viewportEl.style.height = '100%';
+            this.stage.handleResize();
+
+            try {
+                const queryPdb = await this.getQueryPdb();
+                if (this.destroyed || !this.stage) return;
+
+                let queryComp = null;
+                if (queryPdb) {
+                    queryComp = await this.loadQueryStructure(queryPdb);
+                    if (this.destroyed || !this.stage) return;
+                }
+
+                const targetComp = await this.buildTargetStructure(alignments, id);
+                if (this.destroyed || !this.stage || !targetComp) return;
+
+                if (queryComp) {
+                    await this.superposeStructures(queryComp, targetComp, alignments);
+                    if (this.destroyed || !this.stage) return;
+                }
+
+                this.addRepresentations(queryComp, targetComp, alignments);
+
+                if (queryComp) {
+                    const querySele = this.mode < 2 
+                        ? alignments.map(
+                            a => `${a.qStartPos}-${a.qEndPos}:${getChainName(a.query)}`
+                        ).join(" or ") 
+                        : getMotif(alignments[0].queryresidues)
+                    queryComp.autoView(querySele, 0);
+                } else {
+                    this.stage.autoView(0);
+                }
+
+                this.isSpinning = true;
+                this.stage.setSpin(true);
+                this.stage.viewer.renderer.domElement.addEventListener('mousedown', this.handleMouseDown);
+            } catch (e) {
+                console.warn('Interactive viewer failed for', id, e);
+            }
+
+            this.$emit('viewer-ready');
+        },
+
+        deactivateViewer() {
+            if (this.activeId === null) return;
+            this.clearStage();
+            this.stage.setSpin(false);
+            this.isSpinning = false;
+            this.stage.viewer.renderer.domElement.removeEventListener('mousedown', this.handleMouseDown);
+
+            // Move canvas back to offscreen container
+            const viewportEl = this.$refs.viewport;
+            this.$refs.offscreenContainer.appendChild(viewportEl);
+            viewportEl.style.width = this.thumbWidth + 'px';
+            viewportEl.style.height = this.thumbHeight + 'px';
+            this.stage.setParameters({ quality: 'low', backgroundColor: this.bgColor() });
+            this.stage.handleResize();
+
+            this.activeId = null;
+            this.activeTargetEl = null;
+            this.queuePaused = false;
+            this.processQueue();
+        },
+
+        async switchViewer(id, alignments, newTargetEl) {
+            this.clearStage();
+            this.stage.setSpin(false);
+            this.isSpinning = false;
+            this.stage.viewer.renderer.domElement.removeEventListener('mousedown', this.handleMouseDown);
+
+            // Move canvas to new target
+            const viewportEl = this.$refs.viewport;
+            newTargetEl.appendChild(viewportEl);
+            this.stage.handleResize();
+            this.activeId = id;
+            this.activeTargetEl = newTargetEl;
+
+            try {
+                const queryPdb = await this.getQueryPdb();
+                if (this.destroyed || !this.stage) return;
+
+                let queryComp = null;
+                if (queryPdb) {
+                    queryComp = await this.loadQueryStructure(queryPdb);
+                    if (this.destroyed || !this.stage) return;
+                }
+
+                const targetComp = await this.buildTargetStructure(alignments, id);
+                if (this.destroyed || !this.stage || !targetComp) return;
+
+                if (queryComp) {
+                    await this.superposeStructures(queryComp, targetComp, alignments);
+                    if (this.destroyed || !this.stage) return;
+                }
+
+                this.addRepresentations(queryComp, targetComp, alignments);
+
+                if (queryComp) {
+                    const querySele = this.mode < 2 
+                        ? alignments.map(
+                            a => `${a.qStartPos}-${a.qEndPos}:${getChainName(a.query)}`
+                        ).join(" or ") 
+                        : getMotif(alignments[0].queryresidues)
+                    queryComp.autoView(querySele, 0);
+                } else {
+                    this.stage.autoView(0);
+                }
+
+                this.isSpinning = true;
+                this.stage.setSpin(true);
+                this.stage.viewer.renderer.domElement.addEventListener('mousedown', this.handleMouseDown);
+            } catch (e) {
+                console.warn('Switch viewer failed for', id, e);
+            }
+
+            this.$emit('viewer-ready');
+        },
+
+        handleMouseDown() {
+            this.isSpinning = false;
+            this.stage.setSpin(false);
+        },
+
+        handleToggleSpin() {
+            if (!this.stage) return;
+            this.isSpinning = !this.isSpinning;
+            this.stage.setSpin(this.isSpinning);
+        },
+
+        handleResetView() {
+            if (!this.stage) return;
+            this.stage.autoView(100);
+        },
+
+        async processQueue() {
+            if (this.queuePaused || this.isRendering || this.thumbnailQueue.length === 0 || this.currentQueueIndex >= this.thumbnailQueue.length) {
+                return;
+            }
+
+            this.isRendering = true;
+            const item = this.thumbnailQueue[this.currentQueueIndex];
+
+            try {
+                if (this.destroyed || !this.stage) return;
+
+                // Skip items without tCa data
+                if (!item.alignments || item.alignments.length === 0 || typeof item.alignments[0].tCa === 'undefined') {
+                    this.currentQueueIndex++;
+                    this.isRendering = false;
+                    this.$nextTick(() => this.processQueue());
+                    return;
+                }
+
+                const queryPdb = await this.getQueryPdb();
+                if (this.destroyed || !this.stage) return;
+
+                const hasQuery = !!queryPdb;
+                let queryComp = null;
+                if (hasQuery) {
+                    queryComp = await this.loadQueryStructure(queryPdb);
+                    if (this.destroyed || !this.stage) return;
+                }
+
+                const targetComp = await this.buildTargetStructure(item.alignments, item.db);
+                if (this.destroyed || !this.stage || !targetComp) {
+                    this.clearStage();
+                    this.currentQueueIndex++;
+                    this.isRendering = false;
+                    this.$nextTick(() => this.processQueue());
+                    return;
+                }
+
+                if (queryComp) {
+                    await this.superposeStructures(queryComp, targetComp, item.alignments);
+                    if (this.destroyed || !this.stage) return;
+                }
+
+                this.addRepresentations(queryComp, targetComp, item.alignments);
+
+                if (queryComp) {
+                    const querySele = this.mode < 2 
+                        ? item.alignments.map(
+                            a => `${a.qStartPos}-${a.qEndPos}:${getChainName(a.query)}`
+                        ).join(" or ")
+                        : getMotif(item.alignments[0].queryresidues)
+                    queryComp.autoView(querySele, 0);
+                } else {
+                    this.stage.autoView(0);
+                }
+
+                await this.captureThumbnail(item.id);
+                this.clearStage();
+            } catch (e) {
+                console.warn('Thumbnail generation failed for', item.id, e);
+                this.clearStage();
+            }
+
+            this.currentQueueIndex++;
+            this.isRendering = false;
+
+            if (!this.destroyed) {
+                this.$nextTick(() => this.processQueue());
+            }
+        },
+    },
+    watch: {
+        thumbnailQueue: {
+            handler(newQueue, oldQueue) {
+                if (!oldQueue || newQueue.length > oldQueue.length) {
+                    this.processQueue();
+                }
+            },
+            deep: true,
+        },
+    },
+    mounted() {
+        this.initStage();
+        this.processQueue();
+    },
+    beforeDestroy() {
+        this.destroyed = true;
+        if (this.stage) {
+            this.stage.dispose();
+            this.stage = null;
+        }
+        recoverLog()
+    },
+}
+</script>
+
+<style scoped>
+.offscreen-container {
+    position: absolute;
+    left: -9999px;
+    top: -9999px;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.offscreen-viewport {
+    overflow: hidden;
+}
+</style>

--- a/frontend/StructureViewerThumbnail.vue
+++ b/frontend/StructureViewerThumbnail.vue
@@ -97,6 +97,7 @@ export default {
                 backgroundColor: this.bgColor(),
                 transparent: true,
                 quality: 'low',
+                sampleLevel: 3,
                 clipNear: -1000,
                 clipFar: 1000,
                 fogFar: 1000,
@@ -104,6 +105,7 @@ export default {
                 tooltip: false,
             });
             this.stage.setSize(this.thumbWidth, this.thumbHeight);
+            this.stage.handleResize()
 
             // To ignore "STAGE LOG ..." things.
             wrapLog()
@@ -353,15 +355,23 @@ export default {
             await new Promise(resolve => requestAnimationFrame(resolve));
             if (this.destroyed || !this.stage) return;
 
-            const blob = await this.stage.makeImage({
-                trim: false,
-                factor: 2,
-                antialias: true,
-                transparent: true,
-            });
-            if (this.destroyed) return;
+            const canvas = document.getElementById(id+'-thumbnail-canvas');
+            const nglCanvas = this.$refs.viewport.querySelector('canvas')
+            let result = false
+            if (canvas) {
 
-            this.$emit('thumbnail-ready', { id, blob });
+                canvas.width = this.thumbWidth
+                canvas.height = this.thumbHeight
+                const ctx = canvas.getContext('2d')
+                ctx.clearRect(0, 0, this.thumbWidth, this.thumbHeight)
+                ctx.imageSmoothingQuality = 'high'
+                ctx.imageSmoothingEnabled = true
+                ctx.drawImage(nglCanvas, 0, 0, this.thumbWidth, this.thumbHeight)
+                result = true
+
+            }
+
+            this.$emit('thumbnail-ready', { id, result });
         },
 
         clearStage() {

--- a/frontend/Top100Folddisco.vue
+++ b/frontend/Top100Folddisco.vue
@@ -1,0 +1,1106 @@
+<template>
+    <div>
+        <v-sheet style="position: sticky; z-index: 99997 !important; padding-bottom: 16px; margin-top: 28px"
+            :style="{'height': headHeight, 'top': headTop,
+                'box-shadow': $vuetify.breakpoint.smAndDown ? 'rgba(0, 0, 0, 0.2) 0px 8px 6px -6px' : '',
+            }"
+        >
+            <v-flex
+                class="d-flex"
+                :style="{
+                    'flex-direction' : $vuetify.breakpoint.mdAndDown ? 'column' : 'row',
+                    'align-items': 'start',
+                    'white-space': 'nowrap',
+                }">
+                <div style="flex-basis: 100%; width: 100%; flex: 1">
+                    <h2 style="margin-top: 0.5em; margin-bottom: 1em; display: inline-block;" class="mr-auto">
+                    <!-- <div style="width: 24px; display: inline-block;"></div> -->
+                     <div style="width: 24px; display: inline-block;"
+                        v-if="!$vuetify.breakpoint.mdAndDown"
+                    ></div>
+                    <v-icon @click="isCollapsed = !isCollapsed" v-else
+                        style="transition: transform 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);"
+                        :style="{'transform': isCollapsed ? 'rotate(-90deg)' : ''}"
+                        :title="isCollapsed ? 'Show actions' : 'Hide actions'"
+                    >
+                        {{ $MDI.ChevronDown }}
+                    </v-icon>
+                    <span>Top 100</span> 
+                    </h2>
+                </div>
+                <v-flex
+                    v-if="!isCollapsed || $vuetify.breakpoint.lgAndUp"
+                    class="d-flex" style="width: 100%"
+                    :style="{
+                        'flex-direction' : $vuetify.breakpoint.mdAndDown ? 'column' : 'row',
+                        'align-items': 'center',
+                        'white-space': 'nowrap',
+                        'gap': '24px',
+                        'flex': $vuetify.breakpoint.mdAndDown ? '0' : '1',
+                        'padding-left': $vuetify.breakpoint.mdAndDown ? '24px' : ''
+                    }"
+                    >
+                    <v-flex class="d-flex" style="flex-basis: 100%; width: 100%;">
+                        <div style="width: 100%">
+                            <h3>Filter
+                                <v-tooltip open-delay="300" top>
+                                    <template v-slot:activator="{ on }">
+                                        <v-icon v-on="on" style="font-size: 16px;">{{ $MDI.HelpCircleOutline }}</v-icon>
+                                    </template>
+                                    <span>Filter hits by which query residues are present in the match. Select a pattern to show only hits matching that specific subset of query residues.</span>
+                                </v-tooltip>
+                            </h3>
+                            <motif-filter
+                                :items="dbGaps"
+                                :value="gapFilter ? gapFilter : ''"
+                                @input="gapFilter = $event"
+                                @click:clear="gapFilter = ''"
+                                :queryresidues="queryresidues"
+                                :color="primaryColor"
+                            >
+                            </motif-filter>
+                        </div>
+                        <v-menu v-show="$vuetify.breakpoint.smAndDown" bottom left :close-on-content-click='false'>
+                            <template v-slot:activator="{on, attrs}">
+                                <v-btn
+                                    icon
+                                    v-bind="attrs"
+                                    v-on="on"
+                                    v-show="$vuetify.breakpoint.smAndDown"
+                                    style="align-self: flex-end; margin-bottom: 16px; margin-left: 8px"
+                                    title="Sort options"
+                                >
+                                    <v-icon>
+                                        {{ $MDI.Sort }}
+                                    </v-icon>
+                                </v-btn>
+                            </template>
+                            <v-list
+                                flat dense
+                            >
+                                <v-list-item-group
+                                    mandatory
+                                    color="primary"
+                                    :value="sortMenuValue"
+                                >
+                                    <v-list-item @click.stop="changeSortMode('idf')">
+                                        <v-list-item-title>IDF-score</v-list-item-title>
+                                        <v-list-item-icon>
+                                            <v-icon :style="{'opacity' : sortKey == 'idf' ? '1' : 0}">
+                                                {{$MDI.Check}}
+                                            </v-icon>
+                                        </v-list-item-icon>
+                                    </v-list-item>
+                                    <v-list-item @click.stop="changeSortMode('rmsd')">
+                                        <v-list-item-title>RMSD</v-list-item-title>
+                                        <v-list-item-icon>
+                                            <v-icon :style="{'opacity' : sortKey == 'rmsd' ? '1' : 0}">
+                                                {{$MDI.Check}}
+                                            </v-icon>
+                                        </v-list-item-icon>
+                                    </v-list-item>
+                                    <v-list-item @click.stop="changeSortMode('node')">
+                                        <v-list-item-title>Node Count</v-list-item-title>
+                                        <v-list-item-icon>
+                                            <v-icon :style="{'opacity' : sortKey == 'node' ? '1' : 0}">
+                                                {{$MDI.Check}}
+                                            </v-icon>
+                                        </v-list-item-icon>
+                                    </v-list-item>
+                                </v-list-item-group>
+                            </v-list>
+                        </v-menu>
+                    </v-flex>
+                </v-flex>
+            </v-flex>
+            
+        </v-sheet>
+        <table class="v-table result-table" style="position:relative; margin-bottom: 3em;"
+            v-if="hasEntries" :style="{'--active-color': primaryColor}">
+            <colgroup>
+                <col style="width: 36px;"> <!--index-->
+                <col style="min-width: 12%;" /> <!-- target -->
+                <col v-if="hasDescription" style="width: 25%;" /> 
+                <col v-if="hasTaxonomy" style="width: 15%;" />
+                <col style="width: 6%;" /> <!-- idf-score --> 
+                <col style="width: 6%;" /> <!-- RMSD --> 
+                <col style="width: 6%;" /> <!-- nodecount -->
+                <col style="min-width: 12%;" /> <!-- Matched residues --> 
+                <!-- <col style="width: 20%;" /> Interresidue --> 
+                <col style="width: 6%;" /> <!-- action -->
+            </colgroup>
+            <thead style="position: sticky; z-index: 99997 !important;" class="sticky-thead"
+                :style="{'top': colheadTop, 
+                'background-color': $vuetify.theme.dark ? '#1e1e1e' : '#fff'}">
+                <tr>
+                    <th class="thin select-all-th" style="position: relative">
+                        <!-- Replaced this checkbox too, for the colored undeterminate state -->
+                        <div class="v-input--selection-controls__input select-all custom-checkbox" id="top#select-all" style="user-select: none;
+                            -webkit-user-select: none; cursor: pointer; position: absolute; top: calc(50% - 12px); left: 6px;" @click.stop="toggleSelectAll($event)" :length="entryLength"
+                            :title="multipleSelectionEnabled ? 'click to select all the entries' : 'select the first entry (multiple selection is WIP)'">
+                            <span aria-hidden="true" class="v-icon notranslate" :class="{'theme--light': !$vuetify.theme.dark, 'theme--dark': $vuetify.theme.dark}">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg">
+                                    <path class="unchecked" d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+                                    <path class="checked" d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
+                                    <path class="undeterminate" d="M17,13H7V11H17M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
+                                </svg>
+                            </span>
+                        </div>
+                    </th>
+                    <th :class="['wide-' + (3 - hasDescription - hasTaxonomy),]">
+                        Target
+                    </th>
+                    <th v-if="hasDescription">
+                        Description
+                        <v-tooltip open-delay="300" top>
+                            <template v-slot:activator="{ on }">
+                                <v-icon v-on="on" style="font-size: 16px; float: right;">{{ $MDI.HelpCircleOutline }}</v-icon>
+                            </template>
+                            <span>Triple click to select whole cell (for very long identifiers)</span>
+                        </v-tooltip>
+                    </th>
+                    <th v-if="hasTaxonomy">Scientific Name</th>
+                    <th class="thin sort-criterion default-down" :class="{'sort-selected':this.sortKey == 'idf', 'sort-down': this.sortOrder < 0}" 
+                        @click="changeSortMode('idf')" title="Click to sort by IDF-score">{{ $vuetify.breakpoint.mdAndDown ? 'IDF' :'IDF-score' }}</th>
+                    <th class="thin sort-criterion" :class="{'sort-selected':this.sortKey == 'rmsd', 'sort-down': this.sortOrder < 0}" 
+                        @click="changeSortMode('rmsd')" title="Click to sort by RMSD">RMSD</th>
+                    <th class="thin sort-criterion default-down" :class="{'sort-selected':this.sortKey == 'node', 'sort-down': this.sortOrder < 0}" 
+                        @click="changeSortMode('node')" title="Click to sort by node count" >Nodes</th>
+                    <th>
+                        {{ $vuetify.breakpoint.lgAndDown ? 'Residues' : 'Matched residues' }}
+                        <v-tooltip open-delay="300" top>
+                            <template v-slot:activator="{ on }">
+                                <v-icon v-on="on" style="font-size: 16px; float: right;">{{ $MDI.HelpCircleOutline }}</v-icon>
+                            </template>
+                            <span>The position of the aligned motif residues in the target</span>
+                        </v-tooltip>
+                    </th>
+                    <!-- <th>Interresidue Dist</th> -->
+                    <th class="alignment-action thin">Structure</th>
+                </tr>
+            </thead>
+            <tbody><tr aria-hidden="true" style="height: 8px"></tr></tbody>
+            <tbody>
+                <template v-for="([ dbIdx, groupidx ], sortIdx) in sortedSplittedIndices" >
+                    <tr v-for="(item, index) in hits.results[dbIdx].alignments[groupidx]" :class="['hit', { 'active' : item.active }]"
+                        :key="`${dbIdx}-${groupidx}-${index}`" @click.stop="$vuetify.breakpoint.smAndDown ? onCheckboxClick(sortIdx, $event) : () => {}"
+                        :style="{'--active-color': idxToColor[dbIdx]}"
+                    >
+                        <td class="entry-checkbox" :id="'top.' + dbIdx + '#' + groupidx">
+                            <!-- performance issue with thousands of v-checkboxes, hardcode the simple checkbox instead -->
+                            <div class="v-input--selection-controls__input custom-checkbox" 
+                            style="user-select: none; -webkit-user-select: none; cursor: pointer; position: absolute; top: calc(50% - 12px); left: 6px;" 
+                            @click.stop="onCheckboxClick(sortIdx, $event)"
+                            :title="multipleSelectionEnabled ? 'click to select, shift-click for multiple selection' : 'click to toggle the selection'">
+                                <span aria-hidden="true" 
+                                    class="v-icon notranslate" 
+                                    :class="{'theme--light': !$vuetify.theme.dark, 'theme--dark': $vuetify.theme.dark}"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg">
+                                        <path class="unchecked" d="M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3M19,5V19H5V5H19Z"></path>
+                                        <path class="checked" d="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.89 20.1,3 19,3Z"></path>
+                                    </svg>
+                                </span>
+                            </div>
+                            <div class="border-td" 
+                            @click.stop="() => $emit('jumpTo', Number(dbIdx))"
+                            :data-text="idxToDb[dbIdx].replaceAll(/_folddisco$/g, '').toUpperCase()"
+                            ></div>
+                        </td>
+                        <td class="db long" data-label="Target" :style="{ 'border-color' : 'var(--active-color)'}">
+                            <a :id="item.id" class="anchor" style="position: absolute; top: 0" @click.stop></a>
+                            <a style="text-decoration: underline; color: #2196f3;" 
+                                v-if="Array.isArray(item.href)" @click.stop="emitForwardDropdown($event, item.href)"
+                                rel="noopener" :title="item.target">{{item.targetname}}</a>
+                            <a v-else :href="item.href" target="_blank" rel="noopener" 
+                                :title="item.target" @click.stop>{{item.targetname}}</a>
+                        </td>
+                        <td class="long" data-label="Description" v-if="hasDescription">
+                            <span :title="item.description ? item.description : '-'">{{ item.description ? item.description : '-'}}</span>
+                        </td>
+                        <td class="long" v-if="hasTaxonomy" data-label="Taxonomy">
+                            <a v-if="item.taxName" :href="'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=' + item.taxId" 
+                            target="_blank" rel="noopener" :title="item.taxName ? item.taxName : '-'" @click.stop>{{item.taxName}}</a>
+                            <span v-else>-</span>
+                        </td>
+                        <td class="thin" data-label="idf-score">{{ item.idfscore }}</td>
+                        <td class="thin" data-label="RMSD">{{ item.rmsd }}</td>
+                        <td class="thin" data-label="Node count">{{ item.nodecount }}</td>
+                        <td data-label="Matched residues">
+                            <span class="matched-residues-text" :title="item.targetresidues">{{ item.targetresidues }}</span>
+                        </td> 
+                        <td class="alignment-action thin" :rowspan="1">
+                            <!-- performance issue with thousands of v-btns, hardcode the minimal button instead -->
+                            <!-- <v-btn @click="showAlignment(item, $event)" text :outlined="alignment && item.target == alignment.target" icon>
+                                <v-icon v-once>{{ $MDI.NotificationClearAll }}</v-icon>
+                            </v-btn> -->
+                            <button 
+                                @click.stop="showAlignment(dbIdx, groupidx, $event)"
+                                type="button"
+                                class="v-btn v-btn--icon v-btn--round v-btn--text v-size--default"
+                                :class="{ 
+                                            'v-btn--outlined' : alignment && item.target == alignment[0].target,
+                                            'theme--dark' : $vuetify.theme.dark
+                                        }"
+                                >
+                                <span class="v-btn__content">
+                                    <span aria-hidden="true" class="v-icon notranslate theme--dark">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg">
+                                        <path d="M5,13H19V11H5M3,17H17V15H3M7,7V9H21V7"></path></svg>
+                                </span></span>
+                            </button>
+                        </td>
+                    </tr>
+                </template>
+            </tbody>
+        </table>
+    </div>
+</template>
+<script>
+import MotifFilter from './MotifFilter.vue';
+
+export default {
+    name: 'Top100Folddisco',
+    components: {MotifFilter},
+    data() {
+        return {
+            origIndicesPerGaps: {},
+            cachedSortedIndices: {},
+            sortKeyCache: {},
+            toggleTargetValue: true,
+            toggleSourceKey: "",
+            toggleSourceIdx: -1,
+            idxToDb: {},
+            idxToColor: {},
+            sortKey: 'node',
+            isCollapsed: false,
+            gapFilter: "",
+            multipleSelectionEnabled: false,
+            selectedTopEntries: 0,
+        }
+    },
+    created() {
+        // Initialize sortKeyCache
+        const obj = {}
+        obj['idf'] = {}
+        obj['rmsd'] = {}
+        obj['node'] = {}
+        const gapToIdx = {}
+
+        let idxs = []
+        let alns = {}
+        for (let [db_idx, hit] of Object.entries(this.hits.results)) {
+            alns = hit.alignments
+            idxs = Object.keys(alns)
+
+            // Storing indices
+            const arr = idxs.map(k => db_idx + "#" + k)
+            if (gapToIdx[""] == undefined) {
+                gapToIdx[""] = []
+            }
+            gapToIdx[""].push(...arr)
+
+            // Caching values required for sorting
+            if (idxs.length > 0) {
+                obj['idf'][db_idx] = Object.fromEntries(idxs.map(k => [k, alns[k][0].idfscore]))
+                obj['rmsd'][db_idx] = Object.fromEntries(idxs.map(k => [k, alns[k][0].rmsd]))
+                obj['node'][db_idx] = Object.fromEntries(idxs.map(k => [k, alns[k][0].nodecount]))
+            }
+            
+            for (let i = 0; i < Object.keys(alns).length; i++) {
+                const item = alns[i]
+                const gap = item[0].gaps
+                if (gapToIdx[gap] == undefined) {
+                    gapToIdx[gap] = []
+                }
+                gapToIdx[gap].push(arr[i])
+            }
+
+            // db name and color caching
+            this.idxToDb[db_idx] = hit.db
+            this.idxToColor[db_idx] = hit.color
+        }
+        
+        this.sortKeyCache = obj
+        this.origIndicesPerGaps = gapToIdx
+    },
+    props: {
+        hits: {
+            type: Object,
+            default: null
+        },
+        selectedStates: {
+            type: Object,
+            default: null
+        },
+        selectedCounts: {
+            type: Number,
+            default: 0,
+        },
+        selectUpperbound: {
+            type: Number,
+            default: 1000
+        },
+        alignment: {
+            type: Object,
+            default: null
+        },
+    },
+    mounted() {
+        if (this.$route.query.d2m && this.$route.query.d2m == 1) {
+            this.multipleSelectionEnabled = true
+        }
+        this.$nextTick(() => {
+            setTimeout(() => {
+                this.reflectSelectionState()
+            }, 0)
+        })
+    },
+    activated() {
+        this.toggleSourceIdx = -1
+        this.toggleTargetValue = true
+        this.$nextTick(() => {
+            setTimeout(() => {
+                this.reflectSelectionState()
+            }, 0)
+        })
+    },
+    computed: {
+        entryLength() {
+            return this.sortedIndices.length
+        },
+        hasEntries() {
+            return this.origIndicesPerGaps[""]?.length > 0
+        },
+        hasDescription() {
+            let value = false
+            for (let hit of Object.values(this.hits.results)) {
+                if (hit.hasDescription && Object.keys(hit.alignments).length > 0) {
+                    value = true
+                    break
+                }
+            }
+            return value
+        },
+        hasTaxonomy() {
+            let value = false
+            for (let hit of Object.values(this.hits.results)) {
+                if (hit.hasTaxonomy && Object.keys(hit.alignments).length > 0) {
+                    value = true
+                    break
+                }
+            }
+            return value
+        },
+        sortedIndices() {
+            if (this.cachedSortedIndices[this.gapFilter] != undefined
+                && this.cachedSortedIndices[this.gapFilter][this.sortKey] != undefined
+            ) return this.cachedSortedIndices[this.gapFilter][this.sortKey]
+
+            if (this.gapFilter == null) this.gapFilter = ""
+            let copiedArrs = [...this.origIndicesPerGaps[this.gapFilter]]
+            let sliced = copiedArrs.sort(this.comparator).slice(0, 100)
+            if (this.cachedSortedIndices[this.gapFilter] == undefined) {
+                this.cachedSortedIndices[this.gapFilter] = {}
+            }
+            this.cachedSortedIndices[this.gapFilter][this.sortKey] = sliced
+
+            return sliced
+        },
+        sortedCount() {
+            if (!this.sortedIndices) return 0
+            return this.sortedIndices.length
+        },
+        comparator() {
+            let sortCache = this.sortKeyCache[this.sortKey]
+            let comp = (a, b) => {
+                let [a_db, a_idx] = a.split("#")
+                let [b_db, b_idx] = b.split("#")
+                return this.sortOrder * ( sortCache[a_db][a_idx] - sortCache[b_db][b_idx])
+            }
+            return comp
+        },
+        headTop() {
+            return "140px"
+        },
+        colheadTop() {
+            const breakpointAddend = this.$vuetify.breakpoint.mdAndDown ? 56 : 0
+            const auxOffset = this.isCollapsed && this.$vuetify.breakpoint.mdAndDown ? -126 : 0
+            return String(274 + breakpointAddend + auxOffset) + 'px'
+        },
+        isGapFilterAvailable() {
+            return !(!this.gapFilter || this.gapFilter == '')
+        },
+        dbGaps() {
+            if (!this.hits) {
+                return [];
+            }
+            return [...Object.keys(this.origIndicesPerGaps), ''];
+        },
+        headHeight() {
+            const auxHeight = this.isCollapsed && this.$vuetify.breakpoint.mdAndDown ? -70 : this.$vuetify.breakpoint.mdAndDown ? 56 : 0
+            return String(auxHeight + 134) + 'px'
+        },
+        sortMenuValue() {
+            switch (this.sortKey) {
+                case 'idf': {
+                    return 0
+                }
+                case 'rmsd': {
+                    return 1
+                }
+                case 'node': {
+                    return 2
+                }
+                default: {
+                    return 2
+                }
+            }
+        },
+        sortedSplittedIndices() {
+            return this.sortedIndices.map(idx => idx.split("#"))
+        },
+        sortOrder() { 
+            if (this.sortKey == 'rmsd') return 1
+            else return -1
+        },
+        queryresidues() {
+            return this.hits.results[0]?.queryresidues ? this.hits.results[0].queryresidues : ""
+        },
+        primaryColor() {
+            return this.$vuetify.theme.dark ? '#2196f3' : '#1976d2'
+        }
+    },
+    methods: {
+        log(a) {
+            console.log(a)
+            return a
+        },
+        toggleSelectAll(value) {
+            if (!this.selectedStates) {
+                return 
+            }
+
+            if (this.selectedTopEntries > 0) {
+                value = false
+            }
+            
+            if (!value) {
+                const arr = []
+                for (const [idx, [dbIdx, entryIdx]] of this.sortedSplittedIndices.entries()) {
+                    if (this.selectedStates[dbIdx][entryIdx]) {
+                        arr.push(this.sortedIndices[idx])
+                    }
+                }
+                this.$emit('bulkToggle', arr, value)
+                return
+            } 
+
+            if (this.multipleSelectionEnabled) {
+                const arr = []
+                let deltaUpperbound = this.selectUpperbound - this.selectedCounts
+                let delta = 0
+                for (let [idx, [dbIdx, entryIdx]] of this.sortedSplittedIndices.entries()) {
+                    if (delta >= deltaUpperbound) {
+                        break
+                    }
+                    if (this.selectedStates[dbIdx][entryIdx] != value) {
+                        arr.push(this.sortedIndices[idx])
+                        delta++
+                    }
+                }
+                if (delta > 0) {
+                    this.$emit('bulkToggle', arr, value)
+                }
+            } else {
+                if (this.selectedCounts > 0) {
+                    this.$emit('clearAll')
+                }
+
+                if (this.sortedSplittedIndices[0]) {
+                    const [dbIdx, entryIdx] = this.sortedSplittedIndices[0]
+                    this.$emit('toggleSelection', dbIdx, entryIdx, true)
+                }
+            }
+        },
+        emitForwardDropdown(event, href) {
+            this.$emit('forwardDropdown', event, href)
+        },
+        showAlignment(dbIdx, groupidx, event) {
+            this.$emit('showAlignment', this.hits.results[dbIdx].alignments[groupidx][0], this.idxToDb[dbIdx], event)
+        },
+        isItemVisible(item) {
+            if (!this.gapFilter) return true
+            return this.gapFilter == '' || item.gaps == this.gapFilter;
+        },
+        onCheckboxClick(idx, event) {
+            if (!this.selectedStates) { 
+                return 
+            }
+
+            let [dbIdx, targetIdx] = this.sortedSplittedIndices[idx]
+            let value = !this.selectedStates[dbIdx][targetIdx]
+
+            const needRangedToggle = this.multipleSelectionEnabled 
+                && event.shiftKey && (this.toggleSourceIdx != idx && this.toggleSourceIdx != -1)
+
+            if (!needRangedToggle) {
+                // simple click. just toggle it.
+                // If selected count exceeds upperbound, than simply ignore
+                if (this.selectedCounts > 0) {
+                    this.$emit('clearAll')
+                }
+
+                if (this.selectedCounts > this.selectUpperbound && value) { 
+                    return 
+                }
+                this.toggleSourceIdx = idx
+                this.toggleTargetValue = value
+                this.$emit('toggleSelection', dbIdx, targetIdx, value)
+            } else {
+                const startIdx = Math.min(this.toggleSourceIdx, idx)
+                const endIdx = Math.max(this.toggleSourceIdx, idx) + 1
+                
+                if (value && this.selectedCounts > this.selectUpperbound) {
+                    return
+                }
+
+                const deltaUpperbound = this.selectUpperbound - this.selectedCounts
+                let delta = 0
+                const deltaUnit = value ? 1 : -1
+                const arr = []
+
+                for (let i = startIdx; i < endIdx; i++) {
+                    if (delta >= deltaUpperbound) {
+                        break
+                    }
+                    let [dbIdx, targetIdx] = this.sortedSplittedIndices[i]
+                    if (this.selectedStates[dbIdx][targetIdx] != value) {
+                        delta += deltaUnit
+                        arr.push(this.sortedIndices[i])
+                    }
+                }
+
+                if (delta != 0) {
+                    this.$emit('bulkToggle', arr, value)
+                }
+            }
+        },
+        reflectSelectionState() {
+            if (!this.selectedStates || Object.keys(this.selectedStates).length == 0) {
+                return
+            }
+
+            let count = 0
+            let value = false
+            let id = ""
+            for (const [idx, [dbIdx, entryIdx]] of this.sortedSplittedIndices.entries()) {
+                id = this.sortedIndices[idx]
+
+                value = this.selectedStates[dbIdx][entryIdx] ? true : false
+                count += value
+
+                document.getElementById('top.' + id)?.classList.toggle('selected', value)
+            }
+            
+            let select_all_button = document.getElementById("top#select-all")
+            if (select_all_button) {
+                select_all_button.classList.toggle('any-selected', count > 0)
+                select_all_button.classList.toggle('all-selected', this.entryLength == count)
+            }
+            this.selectedTopEntries = count
+        },
+        changeSortMode(key) {
+            if (this.sortKey == key) return
+
+            this.sortKey = key
+            this.toggleSourceKey = ""
+            this.toggleSourceIdx = -1
+            this.toggleTargetValue = true
+
+            this.$nextTick(() => {
+                setTimeout(() => {
+                    this.reflectSelectionState()
+                }, 0)
+            })
+        },
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.hide {
+    display: none;
+}
+
+.result-table {
+    transform: translateY(0);
+    a.anchor {
+        display: block;
+        position: relative;
+        top: -125px;
+        visibility: hidden;
+    }
+
+    a:not([href]) {
+        color: #333;
+        &:not([href]):hover {
+            text-decoration: none;
+        }
+    }
+
+    tbody {
+        counter-reset: row;
+    }
+
+    tbody tr.hit {
+        counter-increment: row;
+    }
+
+    td, th {
+        padding: 0 6px;
+        text-align: left;
+    }
+
+    .hit.active {
+        background: #f9f9f9;
+    }
+
+    // tbody:hover td[rowspan], tbody tr:hover {
+    //     background: #eee;
+    // }
+
+    .alignment-action {
+        text-align: center;
+        word-wrap: normal;
+    }
+}
+
+.theme--dark {
+    .result-table {
+        a:not([href])  {
+            color: #eee;
+        }
+
+        .hit.active {
+            background: #333;
+        }
+
+        // tbody:hover td[rowspan], tbody tr:hover {
+        //     background: #333;
+        // }
+    }
+}
+.matched-residues-text {
+    display: inline-block;
+    max-width: 100%;
+    overflow: scroll;
+    scrollbar-width: none;
+}
+
+
+
+// Sticky thead border
+thead.sticky-thead th {
+    position: relative;
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+thead.sticky-thead th::before {
+    content: "";
+    width: 100%;
+    bottom: 0;
+    left: 0;
+    background-color: rgba(0, 0, 0, 0.12);
+    position: absolute;
+    height: 1px;
+    display: block;
+    z-index: inherit;
+}
+.theme--dark thead.sticky-thead th::before {
+    background-color: rgba(255, 255, 255, 0.12);
+}
+
+thead.sticky-thead th.sort-criterion {
+    cursor: pointer;
+    background-color: transparent;
+    transition: color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), background-color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+thead.sticky-thead th.sort-criterion:not(.sort-selected):hover  {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+thead.sticky-thead th.sort-criterion:not(.sort-selected):active  {
+    background-color: rgba(0, 0, 0, 0.15);
+}
+
+.theme--dark .sticky-thead th.sort-criterion:not(.sort-selected):hover  {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.theme--dark thead.sticky-thead th.sort-criterion:not(.sort-selected):active  {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+thead.sticky-thead th.sort-criterion.sort-selected:hover  {
+    background-color: color-mix(in srgb, var(--active-color) 12%, transparent);
+}
+
+thead.sticky-thead th.sort-criterion.sort-selected:active  {
+    background-color: color-mix(in srgb, var(--active-color) 20%, transparent);
+}
+
+thead.sticky-thead th.sort-criterion::before {
+    transition: background-color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), height 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), bottom 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+thead.sticky-thead th.sort-criterion::after {
+    transform-origin: bottom center;
+    content: "";
+    width: 0;
+    height: 0;
+    bottom: 1px;
+    right: 0;
+    position: absolute;
+    display: block;
+    z-index: inherit;
+    border-bottom: 7px solid transparent;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    background-color: transparent;
+    transition: transform 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), border-bottom-color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), bottom 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+thead.sticky-thead th.sort-criterion:not(.sort-selected):hover::after {
+    border-bottom-color: rgba(0, 0, 0, 0.15);
+}
+
+.theme--dark .sticky-thead th.sort-criterion:not(.sort-selected):hover::after {
+    border-bottom-color: rgba(255, 255, 255, 0.15);
+}
+
+thead.sticky-thead th.sort-criterion:not(.sort-selected).default-down:hover::after {
+    bottom: 0px;
+    transform: scaleY(-1);
+}
+
+thead.sticky-thead th.sort-criterion.sort-selected::before {
+    background-color: var(--active-color);
+    height: 2px;
+    bottom: -1px;
+}
+
+thead.sticky-thead th.sort-criterion.sort-selected::after {
+    border-bottom-color: var(--active-color);
+}
+
+thead.sticky-thead th.sort-criterion.sort-selected:not(.sort-down)::after {
+    bottom: 1px;
+}
+
+thead.sticky-thead th.sort-criterion.sort-selected.sort-down::after {
+    bottom: -1px;
+    transform: scaleY(-1);
+}
+
+tr.hit .entry-checkbox:not(.selected) path.checked {
+    opacity: 0;
+}
+
+tr.hit .entry-checkbox.selected path.unchecked{
+    opacity: 0;
+}
+
+th.select-all-th .select-all path.undeterminate {
+    opacity: 0;
+}
+
+th.select-all-th .select-all.any-selected:not(.all-selected) path.undeterminate {
+    opacity: 1;
+}
+
+th.select-all-th .select-all:not(.all-selected) path.checked {
+    opacity: 0;
+}
+
+th.select-all-th .select-all.any-selected path.unchecked {
+    opacity: 0;
+}
+
+tr.hit .entry-checkbox svg, .select-all svg {
+    transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+    transition: background-color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+tr.hit .entry-checkbox, .select-all {
+    position: relative;
+}
+
+.custom-checkbox::before,
+.custom-checkbox::after {
+    content: '';
+    transition: opacity  0.3s cubic-bezier(0.075, 0.82, 0.165, 1), background-color  0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+    border-radius: 50%;
+    cursor: pointer;
+    width: 34px;
+    height: 34px;
+    top: calc(50% - 17px);
+    left: calc(50% - 17px);
+    position: absolute;
+    background-color: inherit;
+}
+
+:not(.selected) > .custom-checkbox:not(.any-selected)::before,
+:not(.selected) > .custom-checkbox:not(.any-selected)::after {
+    background-color: rgba(0,0,0,0.54);
+}
+
+.theme--dark :not(.selected) > .custom-checkbox:not(.any-selected)::before,
+.theme--dark :not(.selected) > .custom-checkbox:not(.any-selected)::after {
+    background-color: #fff;
+}
+
+.selected .custom-checkbox::before,
+.selected .custom-checkbox::after,
+.custom-checkbox.any-selected::before,
+.custom-checkbox.any-selected::after
+{
+    background-color: var(--active-color);
+}
+
+.custom-checkbox:not(:hover)::before {
+    opacity: 0;
+}
+
+.custom-checkbox:hover::before {
+    opacity: 0.2;
+}
+
+.custom-checkbox::after {
+    opacity: 0;
+    transition: opacity  0.3s cubic-bezier(0.075, 0.82, 0.165, 1), background-color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), transform 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+    transform: scale(0);
+    transform-origin: center center;
+}
+
+.custom-checkbox:active::after {
+    opacity: 0.2;
+    transform: scale(1);
+}
+
+tr.hit .entry-checkbox.selected svg, .select-all.any-selected svg {
+    fill: var(--active-color);
+}
+
+tr.hit:has(.invisible) {
+    display: none;
+}
+th.sort-criterion {
+    cursor: pointer;
+}
+
+th.sort-criterion.sort-selected {
+    color: var(--active-color);
+}
+
+
+@media print, screen and (min-width: 961px) {
+    .result-table {
+        table-layout: fixed;
+        border-collapse: collapse;
+        width: 100%;
+        th.thin, td.thin {
+            white-space: nowrap;
+        }
+        .long {
+            overflow: hidden;
+            word-break: keep-all;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        th {
+            // overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        td:has(.border-td) {
+            position: relative;
+            overflow-y: unset;
+        }
+        div.border-td {
+            background-color: var(--active-color);
+            position: absolute;
+            left: calc(100% - 2.5px);
+            top: 0;
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: white;
+            width: auto;
+            max-width: 5px;
+            padding: 4px 0 4px 5px;
+            height: 100%;
+            transition: all 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+            cursor: pointer;
+        }
+        div.border-td::before {
+            content: attr(data-text);
+            background-color: var(--active-color);
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 1.375rem;
+            max-width: 5px;
+            overflow: hidden;
+            white-space: nowrap;
+            padding-left: 5px;
+            transition: all 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+        }
+        div.border-td:hover::before {
+            max-width: 120px;
+            padding: 0 5px;
+        }
+    }
+}
+
+@media print {
+    .result-table .alignment-action {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 960px) {
+    .result-table {
+        width: 100%;
+        col {
+            width: auto !important;
+        }
+        .long {
+            height: 100% !important;
+            white-space: normal !important;
+            min-height: 48px;
+        }
+        .hits {
+            min-width: 300px;
+        }
+
+        tbody td a {
+            min-width: 100px;
+        }
+        tbody td.graphical div.ruler {
+            margin: 10px 0;
+        }
+        
+        td.entry-checkbox {
+            display: none;
+        }
+
+        thead {
+            display: none;
+        }
+        tfoot th {
+            border: 0;
+            display: inherit;
+        }
+        tr.hit {
+            box-shadow: 0 2px 3px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.1);
+            max-width: 100%;
+            position: relative;
+            display: block;
+            padding: 2em;
+            margin-left: 2em;
+            margin-right: 2em;
+            cursor: pointer;
+        }
+
+        tr.hit:has(.selected) {
+            outline: 4px solid color-mix(in srgb, var(--active-color) 60%, transparent);
+            outline-offset: -2px;
+        }
+
+        tr:not(.hit) {
+            position: relative
+        }
+
+        tr:not(.hit)::after {
+            content: "";
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: 0;
+            height: 1px;
+            background-color: #cfcfcf;
+        }
+
+        tr td {
+            border: 0;
+            display: inherit;
+        }
+        tr td:last-child {
+            border-bottom: 0;
+        }
+        tr:not(:last-child) {
+            margin-bottom: 1rem;
+        }
+        tr:not(.is-selected) {
+            background: inherit;
+        }
+        tr:not(.is-selected):hover {
+            background-color: inherit;
+        }
+        tr.detail {
+            margin-top: -1rem;
+        }
+        tr:not(.detail):not(.is-empty):not(.table-footer) td:not(.entry-checkbox) {
+            display: flex;
+            border-bottom: 1px solid #eee;
+            flex-direction: row;
+
+            &:last-child {
+                border-bottom: 0;
+            }
+        }
+        tr:not(.detail):not(.is-empty):not(.table-footer) td:before {
+            content: attr(data-label);
+            font-weight: 600;
+            margin-right: auto;
+            padding-right: 0.5em;
+            word-break: keep-all;
+            flex: 1;
+            white-space: nowrap;
+        }
+
+        tbody td a, tbody td span {
+            flex: 2;
+            margin-left: auto;
+            text-align: right;
+            word-wrap: anywhere;
+        }
+    }
+        .matched-residues-text {
+        white-space: normal;
+        word-break: break-all;
+        max-width: none;
+    }
+}
+
+.alignment {
+    position:absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 999;
+    box-shadow: 0 3px 5px -1px rgba(0,0,0,.2),0 6px 10px 0 rgba(0,0,0,.14),0 1px 18px 0 rgba(0,0,0,.12) !important;
+
+    .residues {
+        font-family: Protsolata, Inconsolata, Consolas, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
+        white-space: pre;
+    }
+
+    .theme--dark & {
+        .residues {
+            color: #fff;
+        }
+    }
+}
+
+</style>

--- a/frontend/Top100Foldseek.vue
+++ b/frontend/Top100Foldseek.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-        <v-sheet style="position: sticky; z-index: 99997 !important; padding-bottom: 16px;" 
-            :db="entryidx" class="sticky-sheet" :class="`result-entry-${entryidx}`" 
-            :style="{'height': headHeight, 'top': headTop,
+        <v-sheet style="position: sticky; z-index: 99997 !important; padding-bottom: 16px; margin-top: 28px" 
+            class="sticky-sheet" 
+            :style="{'height': headHeight, 'top': '140px',
                 'box-shadow': $vuetify.breakpoint.smAndDown ? 'rgba(0, 0, 0, 0.2) 0px 8px 6px -6px' : '',
                 'padding-bottom': $vuetify.breakpoint.smAndDown ? 0 : '16px',
             }">
@@ -10,33 +10,16 @@
                 'align-items': 'center', 'justify-content': $vuetify.breakpoint.smAndDown ? 'center' : 'space-between'}">
                 <h2 style="margin-top: 0.5em; margin-bottom: 1em; display: inline-block;" class="mr-auto">
                     <div style="width: 24px; display: inline-block;"
-                        v-if="!$vuetify.breakpoint.smAndDown"
                     ></div>
-                    <v-icon @click="isCollapsed = !isCollapsed"
-                        v-if="$vuetify.breakpoint.smAndDown"
-                        style="transition: transform 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);"
-                        :style="{'transform': isCollapsed ? 'rotate(-90deg)' : ''}"
-                        :title="isCollapsed ? 'Show actions' : 'Hide actions'"
-                    >
-                        {{ $MDI.ChevronDown }}
-                    </v-icon>
-                    <span style="text-transform: uppercase;">{{ entry.db }}</span> <small>{{entryLength > 1 ? entryLength.toString() + " hits" : entryLength > 0 ? "1 hit" : "no hit" }}</small>
+                    <span>Top 100</span>
                 </h2>
 
                 <div
                     style="display: flex; justify-content: center; align-items: center;" :style="{'width' : $vuetify.breakpoint.smAndDown ? '100%' : ''}"
-                    v-if="!$vuetify.breakpoint.smAndDown || !isCollapsed"
                 >
                     <div style="display: flex; justify-content: center; align-items: center;"
                     :style="{'width': $vuetify.breakpoint.smAndDown ? '100%' : '', 'flex-direction': $vuetify.breakpoint.smAndDown ? 'column' : 'row'}">
-                        <!-- Button to toggle Sankey Diagram visibility -->
-                        <v-btn v-if="hasEntries && entry.hasTaxonomy && !isComplex" @click="toggleSankeyVisibility(entry.db)" :class="{ 'mr-2': $vuetify.breakpoint.mdAndUp , 'mb-2': $vuetify.breakpoint.smAndDown}" large>
-                            <!-- TODO: later, isSankeyVisible should be modified as bool, not an object
-                                after ResultFoldDisco also is refactored as well. 
-                            -->
-                            {{ isSankeyVisible[entry.db] ? 'Hide Taxonomy' : 'Show Taxonomy' }}
-                        </v-btn>
-                        <v-btn-toggle v-if="hasEntries" mandatory :value="tableMode" @change="switchTableMode" :class="{'mb-2': $vuetify.breakpoint.smAndDown}">
+                        <v-btn-toggle v-if="hasEntries" mandatory :value="tableMode" @change="$emit('switchTableMode', $event)" :class="{'mb-2': $vuetify.breakpoint.smAndDown}">
                             <v-btn>
                                 Graphical
                             </v-btn>
@@ -66,14 +49,14 @@
                         >
                             <v-list-item-group
                                 mandatory
-                                :color="entry.color"
+                                color="primary"
                                 :value="sortMenuValue"
                                 >
                                 <v-list-item v-if="isComplex" @click.stop="changeSortMode('qtm')">
                                     <v-list-item-title>Query TM-score</v-list-item-title>
                                     <v-list-item-icon>
                                         <v-icon :style="{'opacity' : sortKey == 'qtm' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
+                                            {{$MDI.Check}}
                                         </v-icon>
                                     </v-list-item-icon>
                                 </v-list-item>
@@ -81,31 +64,7 @@
                                     <v-list-item-title>Target TM-score</v-list-item-title>
                                     <v-list-item-icon>
                                         <v-icon :style="{'opacity' : sortKey == 'ttm' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
-                                        </v-icon>
-                                    </v-list-item-icon>
-                                </v-list-item>
-                                <v-list-item @click.stop="changeSortMode('target')">
-                                    <v-list-item-title>Target</v-list-item-title>
-                                    <v-list-item-icon>
-                                        <v-icon :style="{'opacity' : sortKey == 'target' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
-                                        </v-icon>
-                                    </v-list-item-icon>
-                                </v-list-item>
-                                <v-list-item v-if="entry.hasDescription" @click.stop="changeSortMode('desc')">
-                                    <v-list-item-title>Description</v-list-item-title>
-                                    <v-list-item-icon>
-                                        <v-icon :style="{'opacity' : sortKey == 'desc' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
-                                        </v-icon>
-                                    </v-list-item-icon>
-                                </v-list-item>
-                                <v-list-item v-if="entry.hasTaxonomy" @click.stop="changeSortMode('tax')">
-                                    <v-list-item-title>Scientific Name</v-list-item-title>
-                                    <v-list-item-icon>
-                                        <v-icon :style="{'opacity' : sortKey == 'tax' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
+                                            {{$MDI.Check}}
                                         </v-icon>
                                     </v-list-item-icon>
                                 </v-list-item>
@@ -113,7 +72,7 @@
                                     <v-list-item-title>Probability</v-list-item-title>
                                     <v-list-item-icon>
                                         <v-icon :style="{'opacity' : sortKey == 'prob' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
+                                            {{$MDI.Check}}
                                         </v-icon>
                                     </v-list-item-icon>
                                 </v-list-item>
@@ -121,7 +80,7 @@
                                     <v-list-item-title>Sequence Id.</v-list-item-title>
                                     <v-list-item-icon>
                                         <v-icon :style="{'opacity' : sortKey == 'seqId' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
+                                            {{$MDI.Check}}
                                         </v-icon>
                                     </v-list-item-icon>
                                 </v-list-item>
@@ -129,7 +88,7 @@
                                     <v-list-item-title>{{ this.mode == 'tmalign' ? 'TM-score' : this.mode == 'lolalign' ? 'LOL-score' : 'E-Value' }}</v-list-item-title>
                                     <v-list-item-icon>
                                         <v-icon :style="{'opacity' : sortKey == 'eval' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
+                                            {{$MDI.Check}}
                                         </v-icon>
                                     </v-list-item-icon>
                                 </v-list-item>
@@ -137,7 +96,7 @@
                                     <v-list-item-title>Score</v-list-item-title>
                                     <v-list-item-icon>
                                         <v-icon :style="{'opacity' : sortKey == 'score' ? '1' : 0}">
-                                            {{ sortOrder < 0 ? $MDI.ChevronDown : $MDI.ChevronUp}}
+                                            {{$MDI.Check}}
                                         </v-icon>
                                     </v-list-item-icon>
                                 </v-list-item>
@@ -147,11 +106,10 @@
                 </div>
             </v-flex>
         </v-sheet>
-        <v-flex v-if="hasEntries && entry.hasTaxonomy && isSankeyVisible[entry.db]" class="mb-2">
-            <SankeyDiagram :rawData="entry.taxonomyreports[0]" :db="entry.db" :currentSelectedNodeId="localSelectedTaxId" :currentSelectedDb="selectedDb" @selectTaxon="handleSankeySelect"></SankeyDiagram>
-        </v-flex>
         <v-sheet v-if="!hasEntries"><div class="text-h5 mt-3 pa-2">No hits found...</div></v-sheet>
-        <table class="v-table result-table" style="position:relative; margin-bottom: 3em;" v-if="hasEntries" :style="{'--active-color': entry.color}">
+        <table class="v-table result-table" style="position:relative; margin-bottom: 3em;" v-if="hasEntries"
+            :style="{'--active-color': $vuetify.theme.dark ? '#2196f3' : '#1976d2'}"
+        >
             <colgroup>
                 <col style="width: 36px;">
                 <template v-if="isComplex">
@@ -159,8 +117,8 @@
                     <col style="width: 6.5%;" />
                 </template>
                 <col style="min-width: 10%;" />
-                <col v-if="entry.hasDescription" style="min-width: 25%;" />
-                <col v-if="entry.hasTaxonomy" style="min-width: 15%;" />
+                <col v-if="hasDescription" style="min-width: 25%;" />
+                <col v-if="hasTaxonomy" style="min-width: 15%;" />
                 <col style="width: 6%;" />
                 <col style="width: 6%;" />
                 <col style="width: 6%;" />
@@ -180,13 +138,13 @@
                 <tr v-if="isComplex">
                     <th colspan="1"></th>
                     <th colspan="2" style="text-align:center; width:10%; border-right: 1px solid #333; border-bottom: 1px solid #333;">Complex</th>
-                    <th :colspan="6 +  entry.hasDescription + entry.hasTaxonomy + ((tableMode == 1) ? 2 : 0)" style="text-align:center; border-bottom: 1px solid #333;">Chain</th>
+                    <th :colspan="6 + hasDescription + hasTaxonomy + ((tableMode == 1) ? 2 : 0)" style="text-align:center; border-bottom: 1px solid #333;">Chain</th>
                 </tr>
                 <tr>
                     <th class="thin select-all-th" style="position: relative">
                         <!-- Replaced this checkbox too, for the colored undeterminate state -->
-                        <div class="v-input--selection-controls__input select-all custom-checkbox" :id="entryidx+'#select-all'" style="user-select: none;
-                            -webkit-user-select: none; cursor: pointer; position: absolute; top: calc(50% - 12px); left: 6px;" @click.stop="toggleDbEntries($event)" :length="entryLength"
+                        <div class="v-input--selection-controls__input select-all custom-checkbox" id="top#select-all" style="user-select: none;
+                            -webkit-user-select: none; cursor: pointer; position: absolute; top: calc(50% - 12px); left: 6px;" @click.stop="toggleSelectAll($event)"
                             title="click to select all the entries">
                             <span aria-hidden="true" class="v-icon notranslate" :class="{'theme--light': !$vuetify.theme.dark, 'theme--dark': $vuetify.theme.dark}">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg">
@@ -204,8 +162,7 @@
                         <th class="thin sort-criterion default-down" :class="{'sort-selected':this.sortKey == 'ttm', 'sort-down': this.sortOrder < 0}"
                             @click="changeSortMode('ttm')" title="Click to sort by Target TM-score" style="border-right: 1px solid #333; ">tTM</th>
                     </template>
-                    <th :class="[`wide-${3 - entry.hasDescription - entry.hasTaxonomy}`, {'sort-selected': this.sortKey == 'target', 'sort-down': this.sortOrder < 0}]" 
-                        class="sort-criterion" title="Click to sort by target name" @click="changeSortMode('target')">
+                    <th :class="[`wide-${3 - hasDescription - hasTaxonomy}`]">
                         <template v-if="isComplex">
                             Chain pairing
                         </template>
@@ -213,8 +170,7 @@
                             Target
                         </template>
                     </th>
-                    <th v-if="entry.hasDescription" class="sort-criterion" :class="{'sort-selected':this.sortKey == 'desc', 'sort-down': this.sortOrder < 0}"
-                    @click="changeSortMode('desc')" title="Click to sort by description">
+                    <th v-if="hasDescription">
                         Description
                         <v-tooltip open-delay="300" top>
                             <template v-slot:activator="{ on }">
@@ -223,14 +179,13 @@
                             <span>Triple click to select whole cell (for very long identifiers)</span>
                         </v-tooltip>
                     </th>
-                    <th v-if="entry.hasTaxonomy"  :class="{'sort-selected':this.sortKey == 'tax', 'sort-down': this.sortOrder < 0}" 
-                        class="sort-criterion" @click="changeSortMode('tax')" title="Click to sort by scientific name">Scientific Name</th>
+                    <th v-if="hasTaxonomy">Scientific Name</th>
                     <th class="thin sort-criterion default-down" :class="{'sort-selected':this.sortKey == 'prob', 'sort-down': this.sortOrder < 0}" 
                         @click="changeSortMode('prob')" title="Click to sort by probability">Prob.</th>
                     <th class="thin sort-criterion default-down" :class="{'sort-selected':this.sortKey == 'seqId', 'sort-down': this.sortOrder < 0}"
                         @click="changeSortMode('seqId')" title="Click to sort by sequence identity">Seq. Id.</th>
                     <th class="thin sort-criterion" :class="{'sort-selected':this.sortKey == 'eval', 'sort-down': this.sortOrder < 0, 'default-down': mode == 'lolalign' || mode == 'tmalign'}"
-                        @click="changeSortMode('eval')" :title="'Click to sort by '+ scoreColumnName">{{ scoreColumnName }}</th> <!-- TODO fixme!! -->
+                        @click="changeSortMode('eval')" :title="'Click to sort by '+ scoreColumnName">{{ scoreColumnName }}</th>
                     <th class="thin sort-criterion default-down" :class="{'sort-selected':this.sortKey == 'score', 'sort-down': this.sortOrder < 0}"
                         v-show="tableMode == 1" @click="changeSortMode('score')" title="Click to sort by score">Score</th>
                     <th v-show="tableMode == 1">Query Pos.</th>
@@ -249,12 +204,13 @@
             </thead>
             <tbody>
                 <tr aria-hidden="true" style="height: 8px"></tr>
-                <template v-for="(groupidx, sortIdx) in visibleSortedIndices" >
-                <tr v-for="(item, index) in entry.alignments[groupidx]" :class="['hit', { 'active' : item.active }]"
+                <template v-for="([dbIdx, groupidx], sortIdx) in sortedSplittedIndices" >
+                <tr v-for="(item, index) in hits.results[dbIdx].alignments[groupidx]" :class="['hit', { 'active' : item.active }]"
                     @click.stop="$vuetify.breakpoint.width <= 960 ? onCheckboxClick(sortIdx, $event) : () => {}"
-                    :key="`${groupidx}-${index}`"
+                    :key="`${dbIdx}-${groupidx}-${index}`" :style="{'--active-color': idxToColor[dbIdx] }"
                     >
-                    <td v-if="index == 0" :rowspan="entry.alignments[groupidx].length" class="entry-checkbox" :id="entryidx + '#' + groupidx">
+                    <td v-if="index == 0" :rowspan="hits.results[dbIdx].alignments[groupidx].length" class="entry-checkbox" :id="'top.' + dbIdx + '#' + groupidx"
+                    >
                         <!-- performance issue with thousands of v-checkboxes, hardcode the simple checkbox instead -->
                         <div class="v-input--selection-controls__input custom-checkbox" 
                         style="user-select: none; -webkit-user-select: none; cursor: pointer; position: absolute; top: calc(50% - 12px); left: 6px;" 
@@ -270,14 +226,22 @@
                                 </svg>
                             </span>
                         </div>
+                        <div v-if="!isComplex" class="border-td" 
+                        @click.stop="() => $emit('jumpTo', Number(dbIdx))"
+                        :data-text="idxToDb[dbIdx].toUpperCase()"
+                        ></div>
                     </td>
                     <template v-if="index == 0 && isComplex">
-                        <td class="thin" data-label="Query TM-score" :rowspan="entry.alignments[groupidx].length">{{ entry.alignments[groupidx][0].complexqtm.toFixed(2) }}</td>
-                        <td class="thin" data-label="Target TM-score" :rowspan="entry.alignments[groupidx].length">{{ entry.alignments[groupidx][0].complexttm.toFixed(2) }}</td>
+                        <td class="thin" data-label="Query TM-score" :rowspan="hits.results[dbIdx].alignments[groupidx].length">{{ item.complexqtm.toFixed(2) }}</td>
+                        <td class="thin" data-label="Target TM-score" :rowspan="hits.results[dbIdx].alignments[groupidx].length"
+                        >
+                        {{ item.complexttm.toFixed(2) }}
+                        <div class="border-td" :data-text="idxToDb[dbIdx].toUpperCase()"
+                        @click.stop="() => $emit('jumpTo', Number(dbIdx))"
+                        ></div>
+                        </td>
                     </template>
-                    <td class="db long" data-label="Target" 
-                        :style="{ 'border-width' : isComplex ? '5px' : null, 
-                            'border-color' : entry.color, }"
+                    <td class="long" data-label="Target" 
                     >
                         <a :id="item.id" class="anchor" style="position: absolute; top: 0" @click.stop></a>
                         <template v-if="isComplex">
@@ -290,17 +254,20 @@
                         <a v-else :href="item.href" target="_blank" rel="noopener" 
                             :title="item.target" @click.stop>{{item.target}}</a>
                     </td>
-                    <td class="long" data-label="Description" v-if="entry.hasDescription">
-                        <span :title="item.description">{{ item.description }}</span>
+                    <td class="long" data-label="Description" v-if="hasDescription">
+                        <span :title="item.description ? item.description : ''">{{ item.description ? item.description : '-' }}</span>
                     </td>
-                    <td class="long" v-if="entry.hasTaxonomy" data-label="Taxonomy">
-                        <a :href="'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=' + item.taxId" 
+                    <td class="long" v-if="hasTaxonomy" data-label="Taxonomy">
+                        <a v-if="item.taxName"
+                            :href="'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=' + item.taxId" 
                             target="_blank" 
                             rel="noopener" 
                             :title="item.taxName" 
-                            @click.stop>
+                            @click.stop
+                        >
                             {{ item.taxName }}
                         </a>
+                        <span v-else>-</span>
                     </td>
                     <td class="thin" data-label="Probability">{{ item.prob }}</td>
                     <td class="thin" data-label="Sequence Identity">{{ item.seqId }}</td>
@@ -311,13 +278,13 @@
                     <td class="graphical" data-label="Position" v-show="tableMode == 0">
                         <Ruler :length="item.qLen" :start="item.qStartPos" :end="item.qEndPos" :color="item.color" :label="index == 0"></Ruler>
                     </td>
-                    <td class="alignment-action" :rowspan="isComplex ? entry.alignments[groupidx].length : 1" v-if="index == 0">
+                    <td class="alignment-action" :rowspan="isComplex ? hits.results[dbIdx].alignments[groupidx].length : 1" v-if="index == 0">
                         <!-- performance issue with thousands of v-btns, hardcode the minimal button instead -->
                         <!-- <v-btn @click="showAlignment(item, $event)" text :outlined="alignment && item.target == alignment.target" icon>
                             <v-icon v-once>{{ $MDI.NotificationClearAll }}</v-icon>
                         </v-btn> -->
                         <button 
-                            @click.stop="showAlignment(groupidx, $event)"
+                            @click.stop="showAlignment(dbIdx, groupidx, $event)"
                             type="button"
                             class="v-btn v-btn--icon v-btn--round v-btn--text v-size--default"
                             :class="{ 
@@ -335,14 +302,8 @@
                         </button>
                     </td>
                 </tr>
-                <tr aria-hidden="true" v-if="isComplex" style="height: 15px" :key="`spacer-${groupidx}`" ></tr>
+                <tr aria-hidden="true" v-if="isComplex" style="height: 15px" :key="`spacer-${dbIdx}-${groupidx}`" ></tr>
                 </template>
-                <tr v-if="renderLimit < sortedIndices.length" ref="sentinel" aria-hidden="true" style="height: 1px"></tr>
-                <tr v-if="renderLimit < sortedIndices.length">
-                    <td :colspan="fullColSpan" style="text-align: center; padding: 8px; color: #888;">
-                        Showing {{ visibleSortedIndices.length }} of {{ sortedIndices.length }} hits
-                    </td>
-                </tr>
             </tbody>
         </table>
     </div>
@@ -350,163 +311,238 @@
 
 <script>
 import Ruler from './Ruler.vue';
-import ResultSankeyMixin from './ResultSankeyMixin.vue';
 
 export default {
-    name: 'ResultFoldseekDB',
-    mixins: [ ResultSankeyMixin ],
+    name: 'Top100Foldseek',
     components: {Ruler},
     data() {
         return {
-            toggleTargetValue: true,
-            toggleSourceIdx: -1,
-            visibilityTable: [],
-            selectedDb: "",
+            origIndices: [],
+            cachedSortedIndices: {},
             sortKey: 'score',
-            sortOrder: -1,
-            isCollapsed: false,
-            renderLimit: 100,
+            sortKeyCache: {},
+            idxToDb: {},
+            idxToColor: {},
+            toggleSourceIdx: -1,
+            toggleTargetValue: true,
+            selectedTopEntries: 0,
         }
-    },
-    created() {
-        this.BATCH_SIZE = 100;
     },
     props: {
-        tableMode: {
-            type: Number,
-            default: 0,
-        },
-        entryidx: {
-            type: Number,
-            default: 0,
-        },
-        entry: {
-            type: Object,
-            default: null
-        },
-        toggleSourceDb: {
-            type: String,
-            default: ""
-        },
-        mode: {
-            type: String,
-            default: ""
-        },
-        selectedStates: {
-            type: Object,
-            default: null
-        },
-        selectedCounts: {
-            type: Number,
-            default: 0,
-        },
-        totalSelectedCounts: {
-            type: Number,
-            default: 0
-        },
-        selectUpperbound: {
-            type: Number,
-            default: 1000
-        },
-        alignment: {
-            type: Object,
-            default: null,
-        },
-        closeAlignment: {
-            type: Function,
-            default: () => {}
-        },
-        onlyOne: {
-            type: Boolean,
-            default: false
-        },
-        isComplex: {
-            type: Boolean,
-            default: false,
-        },
+        hits: {type: Object, required: true},
+        mode: {type: String, default: ""},
+        isComplex: {type: Boolean, default: false},
+        tableMode: {type: Number, default: 0},
+        alignment: {default: null},
+        selectedStates: {default: null},
+        selectedCounts: {default: 0},
+        selectUpperbound: {default: 1000},
     },
-    watch: {
-        filteredHitsTaxIds: {
-            handler(n, o) {
-                // this.log(n)
-                this.toggleSourceIdx = -1
-                this.renderLimit = this.BATCH_SIZE
-                // Set visibility data for ALL entries
-                if (!n || n.length == 0) {
-                    this.visibilityTable = Array(this.entryLength).fill(true)
-                } else {
-                    for (let i = 0; i < this.entryLength; i++) {
-                        this.visibilityTable[i] = this.isGroupVisible(this.entry.alignments[i])
-                    }
-                }
-                // Toggle DOM only for rendered entries (by sorted position)
-                let upperbound = Math.min(this.sortedIndices.length, this.renderLimit)
-                for (let i = 0; i < upperbound; i++) {
-                    let entryIdx = this.sortedIndices[i]
-                    let id = this.entryidx + '#' + String(entryIdx)
-                    let el = document.getElementById(id)
-                    if (el) {
-                        el.classList.toggle('invisible', !this.visibilityTable[entryIdx])
-                    }
-                }
-                this.$nextTick(() => { this.setupObserver() })
-            },
-            immediate: false,
-            deep: true,
-        },
-        toggleSourceDb(n, o) {
-            if (n != this.db) {
-                this.toggleSourceIdx = -1
-            }
-        },
-        entry(n, o) {
-            if (n && this.visibilityTable.length == 0) {
-                this.visibilityTable = Array(this.entryLength).fill(true)
-            }
-            if (n) {
-                this.$nextTick(() => { this.setupObserver() })
-            }
-        }
-    },
-    mounted() {
-        if (this.entry && this.visibilityTable.length == 0) {
-            this.visibilityTable = Array(this.entryLength).fill(true)
-            this.selectedDb = this.db
+    methods: {
+        changeSortMode(key) {
+            if (key == this.sortKey) return
+            
+            this.sortKey = key
+            this.toggleSourceIdx = -1
+            this.toggleTargetValue = true
+            
             this.$nextTick(() => {
                 setTimeout(() => {
                     this.reflectSelectionState()
                 }, 0)
             })
-        }
-        this.setupObserver()
+        },
+        toggleSelectAll(value) {
+            if (!this.selectedStates) {
+                return 
+            }
+
+            if (this.selectedTopEntries > 0) {
+                value = false
+            }
+            
+            if (!value) {
+                const arr = []
+                for (const [idx, [dbIdx, entryIdx]] of this.sortedSplittedIndices.entries()) {
+                    if (this.selectedStates[dbIdx][entryIdx]) {
+                        arr.push(this.sortedIndices[idx])
+                    }
+                }
+                this.$emit('bulkToggle', arr, value)
+                return
+            } 
+
+            const arr = []
+            let deltaUpperbound = this.selectUpperbound - this.selectedCounts
+            let delta = 0
+            for (let [idx, [dbIdx, entryIdx]] of this.sortedSplittedIndices.entries()) {
+                if (delta >= deltaUpperbound) {
+                    break
+                }
+                if (this.selectedStates[dbIdx][entryIdx] != value) {
+                    arr.push(this.sortedIndices[idx])
+                    delta++
+                }
+            }
+            if (delta > 0) {
+                this.$emit('bulkToggle', arr, value)
+            }
+        },
+        onCheckboxClick(idx, event) {
+            if (!this.selectedStates) { 
+                return 
+            }
+
+            let [dbIdx, targetIdx] = this.sortedSplittedIndices[idx]
+            let value = !this.selectedStates[dbIdx][targetIdx]
+
+            const needRangedToggle = event.shiftKey && (this.toggleSourceIdx != idx && this.toggleSourceIdx != -1)
+
+            if (!needRangedToggle) {
+                // simple click. just toggle it.
+                // If selected count exceeds upperbound, than simply ignore
+                if (this.selectedCounts > this.selectUpperbound && value) { 
+                    return 
+                }
+                this.toggleSourceIdx = idx
+                this.toggleTargetValue = value
+                this.$emit('toggleSelection', dbIdx, targetIdx, value)
+            } else {
+                const startIdx = Math.min(this.toggleSourceIdx, idx)
+                const endIdx = Math.max(this.toggleSourceIdx, idx) + 1
+                
+                if (value && this.selectedCounts > this.selectUpperbound) {
+                    return
+                }
+
+                const deltaUpperbound = this.selectUpperbound - this.selectedCounts
+                let delta = 0
+                const deltaUnit = value ? 1 : -1
+                const arr = []
+
+                for (let i = startIdx; i < endIdx; i++) {
+                    if (delta >= deltaUpperbound) {
+                        break
+                    }
+                    let [dbIdx, targetIdx] = this.sortedSplittedIndices[i]
+                    if (this.selectedStates[dbIdx][targetIdx] != value) {
+                        delta += deltaUnit
+                        arr.push(this.sortedIndices[i])
+                    }
+                }
+
+                if (delta != 0) {
+                    this.$emit('bulkToggle', arr, value)
+                }
+            }
+        },
+        showAlignment(dbIdx, groupidx, event) {
+            this.$emit('showAlignment',this.hits.results[dbIdx].alignments[groupidx], this.idxToDb[dbIdx], event)
+        },
+        reflectSelectionState() {
+            if (!this.selectedStates || Object.keys(this.selectedStates).length == 0) {
+                return
+            }
+
+            let count = 0
+            let value = false
+            let id = ""
+            for (const [idx, [dbIdx, entryIdx]] of this.sortedSplittedIndices.entries()) {
+                id = this.sortedIndices[idx]
+
+                value = this.selectedStates[dbIdx][entryIdx] ? true : false
+                count += value
+
+                document.getElementById('top.' + id)?.classList.toggle('selected', value)
+            }
+            
+            let select_all_button = document.getElementById("top#select-all")
+            if (select_all_button) {
+                select_all_button.classList.toggle('any-selected', count > 0)
+                select_all_button.classList.toggle('all-selected', this.entryLength == count)
+            }
+            this.selectedTopEntries = count
+        },
+        emitForwardDropdown(event, href) {
+            this.$emit('forwardDropdown', event, href)
+        },
     },
-    beforeDestroy() {
-        if (this._observer) {
-            this._observer.disconnect()
-            this._observer = null
+    created() {
+        // Initialize sortKeyCache
+        const obj = {}
+        obj['qtm'] = {}
+        obj['ttm'] = {}
+        obj['prob'] = {}
+        obj['seqId'] = {}
+        obj['eval'] = {}
+        obj['score'] = {}
+
+        let idxs = []
+        let alns = {}
+        for (let [db_idx, hit] of Object.entries(this.hits.results)) {
+            alns = hit.alignments
+            idxs = Object.keys(alns)
+
+            // Storing indices
+            const arr = idxs.map(k => db_idx + "#" + k)
+            this.origIndices.push(...arr)
+
+            // Caching values required for sorting
+            if (idxs.length > 0) {
+                obj['prob'][db_idx] = Object.fromEntries(idxs.map(k => [k, Math.max(...alns[k].map(e => e.prob))]))
+                obj['seqId'][db_idx] = Object.fromEntries(idxs.map(k => [k, Math.max(...alns[k].map(e => e.seqId))]))
+                obj['score'][db_idx] = Object.fromEntries(idxs.map(k => [k, Math.max(...alns[k].map(e => e.score))]))
+                const comp = this.mode == 'tmalign' || this.mode == 'lolalign' ? Math.max : Math.min
+                obj['eval'][db_idx] = Object.fromEntries(idxs.map(k => [k, comp(...alns[k].map(e => e.eval))]))
+                
+                if (this.isComplex) {
+                    obj['qtm'][db_idx] = Object.fromEntries(idxs.map(k => [k, Math.max(...alns[k].map(e => e.complexqtm))]))
+                    obj['ttm'][db_idx] = Object.fromEntries(idxs.map(k => [k, Math.max(...alns[k].map(e => e.complexttm))])) 
+                }
+            }
+            // db name and color caching
+            this.idxToDb[db_idx] = hit.db
+            this.idxToColor[db_idx] = hit.color
         }
+        
+        this.sortKeyCache = obj
+    },
+    mounted() {
+        this.$nextTick(() => {
+            setTimeout(() => {
+                this.reflectSelectionState()
+            }, 0)
+        })
+    },
+    activated() {
+        this.toggleSourceIdx = -1
+        this.toggleTargetValue = true
+        this.$nextTick(() => {
+            setTimeout(() => {
+                this.reflectSelectionState()
+            }, 0)
+        })
     },
     computed: {
-        origIndicesArr() {
-            return this.entry ? Object.keys(this.entry.alignments).map(i => Number(i)) : []
-        },
-        db() {
-            return this.entry ? this.entry.db : ""
-        },
         entryLength() {
-            return this.entry ? Object.values(this.entry.alignments).length : 0
+            return this.sortedIndices.length
         },
         hasEntries() {
-            return this.entry ? this.entryLength > 0 : false
+            return this.origIndices.length > 0
         },
-        // isComplex() {
-        //     return this.entry?.alignments?.[0]?.[0]?.complexqtm != null
-        // },
-        anySelected() {
-            return this.selectedCounts > 0
+        hasDescription() {
+            let value = false
+            for (let hit of Object.values(this.hits.results)) {
+                value = value || (hit.hasDescription && Object.keys(hit.alignments).length > 0)
+            }
+            return value
         },
-        selectAllStatus() {
-            return this.selectedCounts == this.entryLength
+        hasTaxonomy() {
+            let value = false
+            for (let hit of Object.values(this.hits.results)) {
+                value = value || (hit.hasTaxonomy && Object.keys(hit.alignments).length > 0)
+            }
+            return value
         },
         scoreColumnName() {
             if (__APP__ == 'foldseek') {
@@ -519,72 +555,8 @@ export default {
             }
             return 'E-Value';
         },
-        sortedIndices() {
-            let copiedArr = [...this.origIndicesArr]
-            return copiedArr.sort(this.comparator)
-        },
-        visibleSortedIndices() {
-            return this.sortedIndices.slice(0, this.renderLimit)
-        },
-        comparator() {
-            let comp = () => {}
-            let sortCache = this.sortKeyCache[this.sortKey]
-            switch (this.sortKey) {
-                case 'prob':
-                case 'seqId':
-                case 'score':
-                case 'eval':
-                case 'qtm':
-                case 'ttm':
-                    comp = (a, b) => {
-                        return this.sortOrder * (sortCache[a] - sortCache[b])
-                    }
-                    break;
-
-                case 'target':
-                    comp = (a, b) => {
-                        return this.sortOrder * (this.entry.alignments[a][0].target.localeCompare(this.entry.alignments[b][0].target))
-                    }
-                    break;
-
-                case 'desc':
-                    comp = (a, b) => {
-                        return this.sortOrder * (this.entry.alignments[a][0].description.localeCompare(this.entry.alignments[b][0].description))
-                    }
-                    break;
-
-                case 'tax':
-                    comp = (a, b) => {
-                        return this.sortOrder * (this.entry.alignments[a][0].taxName.localeCompare(this.entry.alignments[b][0].taxName))
-                    }
-                    break;
-            
-                default:
-                    break;
-            }
-            return comp
-        },
-        headTop() {
-            return this.onlyOne ? '92px' : '140px'
-        },
-        headHeight() {
-            const auxHeight = this.$vuetify.breakpoint.smAndDown ? !this.isCollapsed ? 56 : 0 : 0
-            const padding = this.$vuetify.breakpoint.smAndDown ? 0 : 16
-            const taxHeight = this.$vuetify.breakpoint.smAndDown 
-                && this.entry.hasTaxonomy 
-                && !this.isComplex
-                && !this.isCollapsed ? 52 : 0
-            return String(auxHeight + 64 + padding + taxHeight) + 'px'
-        },
-        colheadTop() {
-            let addend = !this.onlyOne ? 48 : 0
-            let breakpointAddend = this.$vuetify.breakpoint.smAndDown ? 108 : 0
-            return String(172 + addend + breakpointAddend) + 'px'
-        },
         sortMenuValue() {
-            const offset = (this.entry.hasDescription ? 1 : 0) 
-                + (this.entry.hasTaxonomy ? 1 : 0)
-                + (this.isComplex ? 2 : 0)
+            const offset = (this.isComplex ? 2 : 0) 
             switch (this.sortKey) {
                 case 'qtm': {
                     return 0
@@ -592,274 +564,64 @@ export default {
                 case 'ttm': {
                     return 1
                 }
-                case 'target': {
-                    return this.isComplex ? 2 : 0
-                }
-                case 'desc': {
-                    return this.isComplex ? 3 : 1
-                }
-                case 'tax': {
-                    return offset
-                }
                 case 'prob': {
-                    return 1 + offset
+                    return 0 + offset
                 }
                 case 'seqId': {
-                    return 2 + offset
+                    return 1 + offset
                 }
                 case 'eval': {
-                    return 3 + offset
+                    return 2 + offset
                 }
                 case 'score': {
-                    return 4 + offset
+                    return 3 + offset
                 }
                 default: {
-                    return 4 + offset
+                    return 3 + offset
                 }
             }
         },
-        fullColSpan() {
-            let defaultVal = 7
-            let complex = this.isComplex ? 2 : 0
-            let desc = this.entry.hasDescription ? 1 : 0
-            let taxonomy = this.entry.hasTaxonomy ? 1: 0
-            let tableMode = this.tableMode == 0 ? 0 : 2
-            return defaultVal + complex + desc + taxonomy + tableMode
-        },
-        sortKeyCache() {
-            const obj = {}
-            const alns = this.entry.alignments
-            const idxs = Object.keys(alns)
-            if (this.entry) {
-                obj['prob'] = Object.fromEntries(idxs.map(k => [ k, Math.max(...alns[k].map(e => e.prob)) ]))
-                obj['seqId'] = Object.fromEntries(idxs.map(k => [ k, Math.max(...alns[k].map(e => e.seqId)) ]))
-                obj['score'] = Object.fromEntries(idxs.map(k => [ k, Math.max(...alns[k].map(e => e.score)) ]))
-                const comp = this.mode == 'tmalign' || this.mode == 'lolalign' ? Math.max : Math.min
-                obj['eval'] = Object.fromEntries(idxs.map(k => [ k, comp(...alns[k].map(e => e.eval)) ]))
-                
-                if (this.isComplex) {
-                    obj['qtm'] = Object.fromEntries(idxs.map(k => [ k, Math.max(...alns[k].map(e => e.complexqtm)) ]))
-                    obj['ttm'] = Object.fromEntries(idxs.map(k => [ k, Math.max(...alns[k].map(e => e.complexttm)) ]))
-                }
+        comparator() {
+            let sortCache = this.sortKeyCache[this.sortKey]
+            let comp = (a, b) => {
+                let [a_db, a_idx] = a.split("#")
+                let [b_db, b_idx] = b.split("#")
+                return this.sortOrder * ( sortCache[a_db][a_idx] - sortCache[b_db][b_idx])
             }
-            return obj
-        }
-    },
-    methods: {
-        setupObserver() {
-            if (this._observer) {
-                this._observer.disconnect()
-            }
-            this._observer = new IntersectionObserver((entries) => {
-                if (entries[0].isIntersecting) {
-                    this.loadMore()
-                }
-            })
-            this.$nextTick(() => {
-                if (this.$refs.sentinel) {
-                    this._observer.observe(this.$refs.sentinel)
-                }
-            })
+            return comp
         },
-        loadMore() {
-            if (this.renderLimit >= this.sortedIndices.length) return
-            const oldLimit = this.renderLimit
-            this.renderLimit += this.BATCH_SIZE
-            this.$nextTick(() => {
-                this.reflectSelectionState()
-                this.applyVisibilityToNewRows(oldLimit)
-                if (this.$refs.sentinel && this._observer) {
-                    this._observer.disconnect()
-                    this._observer.observe(this.$refs.sentinel)
-                }
-            })
+        sortOrder() {
+            if (this.sortKey == 'eval' && (this.mode != 'tmalign' && this.mode != 'lolalign')) return 1
+            else return -1
         },
-        applyVisibilityToNewRows(oldLimit) {
-            if (!this.filteredHitsTaxIds || this.filteredHitsTaxIds.length === 0) return
-            const newLimit = Math.min(this.sortedIndices.length, this.renderLimit)
-            for (let i = oldLimit; i < newLimit; i++) {
-                const entryIdx = this.sortedIndices[i]
-                const id = this.entryidx + '#' + String(entryIdx)
-                const el = document.getElementById(id)
-                if (el) {
-                    el.classList.toggle('invisible', !this.visibilityTable[entryIdx])
-                }
-            }
-        },
-        log(a) {
-            console.log(a)
-            return a
-        },
-        switchTableMode(newVal) {
-            this.$emit('switchTableMode', newVal);
-        },
-        toggleDbEntries(value) {
-            if (!this.selectedStates) {
-                return 
-            }
-
-            if (this.selectedCounts > 0) {
-                value = false
+        sortedIndices() {
+            // returns sorted indices, calculating on-the-fly
+            if (this.cachedSortedIndices[this.sortKey]) {
+                return this.cachedSortedIndices[this.sortKey]
             }
             
-            if (!value) {
-                const arr = []
-                for (let i = 0; i < this.entryLength; i++) {
-                    if (this.selectedStates[i]) {
-                        arr.push(i)
-                    }
-                }
-                this.$emit('bulkToggle', arr, value)
-                return
-            } 
-
-            const arr = []
-            let deltaUpperbound = this.selectUpperbound - this.totalSelectedCounts
-            let delta = 0
-            for (let i in this.sortedIndices) {
-                if (delta >= deltaUpperbound) {
-                    break
-                }
-                if (this.visibilityTable[i] && this.selectedStates[i] != value) {
-                    arr.push(i)
-                    delta++
-                }
-            }
-            if (delta > 0) {
-                this.$emit('bulkToggle', arr, value)
-            }
+            let copiedArr = [...this.origIndices]
+            let sliced = copiedArr.sort(this.comparator).slice(0, 100)
+            this.cachedSortedIndices[this.sortKey] = sliced
+            
+            return sliced
         },
-        emitForwardDropdown(event, href) {
-            this.$emit('forwardDropdown', event, href)
+        sortedSplittedIndices() {
+            return this.sortedIndices.map(idx => idx.split("#"))
         },
-        showAlignment(groupidx, event) {
-            this.$emit('showAlignment', this.entry.alignments[groupidx], event)
+        headHeight() {
+            const auxHeight = this.$vuetify.breakpoint.smAndDown ? 54 : 16
+            return String(auxHeight + 64) + 'px'
         },
-        isGroupVisible(group) {
-            if (!this.filteredHitsTaxIds || this.filteredHitsTaxIds.length === 0) {
-                return true;
-            }
-            let taxFiltered = group.filter(item => this.filteredHitsTaxIds.includes(Number(item.taxId)));
-            return taxFiltered.length > 0;
+        colheadTop() {
+            const breakpointAddend = this.$vuetify.breakpoint.smAndDown ? 108 : 0
+            return String(48 + 172 + breakpointAddend) + 'px'
         },
-        onCheckboxClick(idx, event) {
-            if (!this.selectedStates) { 
-                return 
-            }
-
-            let targetIdx = this.sortedIndices[idx]
-            let value = !this.selectedStates[targetIdx]
-
-            const needRangedToggle = event.shiftKey && (this.toggleSourceIdx != idx && this.toggleSourceIdx != -1)
-
-            if (!needRangedToggle) {
-                // simple click. just toggle it.
-                // If selected count exceeds upperbound, than simply ignore
-                if (this.totalSelectedCounts > this.selectUpperbound && value) { 
-                    return 
-                }
-                this.toggleSourceIdx = idx
-                this.toggleTargetValue = value
-                this.$emit('updateToggleSource', this.db)
-                this.$emit('toggleSelection', targetIdx, value)
-            } else {
-                const startIdx = Math.min(this.toggleSourceIdx, idx)
-                const endIdx = Math.max(this.toggleSourceIdx, idx) + 1
-                this.handleRangedToggle(startIdx, endIdx, this.toggleTargetValue)
-            }
-        },
-        handleRangedToggle(startIdx, endIdx, value) {
-            if (!this.selectedStates || this.totalSelectedCounts > this.selectUpperbound && value) {
-                return
-            }
-
-            const deltaUpperbound = this.selectUpperbound - this.totalSelectedCounts
-            let delta = 0
-            const deltaUnit = value ? 1 : -1
-            const arr = []
-
-            for (let i = startIdx; i < endIdx; i++) {
-                if (delta >= deltaUpperbound) {
-                    break
-                }
-                let targetIdx = this.sortedIndices[i]
-                if (this.visibilityTable[targetIdx] && this.selectedStates[targetIdx] != value) {
-                    delta += deltaUnit
-                    arr.push(targetIdx)
-                }
-            }
-
-            if (delta != 0) {
-                this.$emit('bulkToggle', arr, value)
-            }
-        },
-        reflectSelectionState() {
-            let value = false
-            let id = ""
-            for (let i = 0; i < this.visibleSortedIndices.length; i++) {
-                let entryIdx = this.visibleSortedIndices[i]
-                value = this.selectedStates[entryIdx]
-                id = this.entryidx + "#" + String(entryIdx)
-                document.getElementById(id)?.classList.toggle('selected', value ? true : false)
-            }
-            let select_all_button = document.getElementById(this.entryidx + '#select-all')
-            if (select_all_button) {
-                select_all_button.classList.toggle('any-selected', this.selectedCounts > 0)
-                select_all_button.classList.toggle('all-selected', this.selectedCounts == this.entryLength)
-            }
-        },
-        changeSortMode(key) {
-            if (this.sortKey == key) {
-                this.sortOrder *= -1
-            } else {
-                this.sortKey = key
-                switch (key) {
-                    case 'target':
-                    case 'desc':
-                    case 'tax':
-                        this.sortOrder = 1
-                        break
-                    case 'prob':
-                    case 'seqId':
-                    case 'score':
-                    case 'qtm':
-                    case 'ttm':
-                        this.sortOrder = -1
-                        break
-                    case 'eval':
-                        if (this.mode == 'lolalign' || this.mode == 'tmalign') {
-                            this.sortOrder = -1
-                        } else {
-                            this.sortOrder = 1
-                        }
-                        break
-                    default:
-                        break;
-                }
-            }
-            this.toggleSourceIdx = -1
-            this.toggleTargetValue = true
-            this.renderLimit = this.BATCH_SIZE
-            this.$nextTick(() => {
-                window.scrollTo({
-                    top: 0,
-                    left: 0,
-                    behavior: 'smooth',
-                })
-                this.setupObserver()
-                setTimeout(() => {
-                    this.reflectSelectionState()
-                }, 0)
-            })
-        },
-    }
+    },
 }
 </script>
 
 <style lang="scss" scoped>
-.db {
-    border-left: 5px solid black;
-}
 
 .result-table {
     transform: translateY(0);
@@ -1144,6 +906,42 @@ th.sort-criterion.sort-selected {
         th {
             // overflow: hidden;
             text-overflow: ellipsis;
+        }
+        td:has(.border-td) {
+            position: relative;
+            overflow-y: unset;
+        }
+        div.border-td {
+            background-color: var(--active-color);
+            position: absolute;
+            left: calc(100% - 2.5px);
+            top: 0;
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: white;
+            width: auto;
+            max-width: 5px;
+            padding: 4px 0 4px 5px;
+            height: 100%;
+            transition: all 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+            cursor: pointer;
+        }
+        div.border-td::before {
+            content: attr(data-text);
+            background-color: var(--active-color);
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 1.375rem;
+            max-width: 5px;
+            overflow: hidden;
+            white-space: nowrap;
+            padding-left: 5px;
+            transition: all 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+        }
+        div.border-td:hover::before {
+            max-width: 120px;
+            padding: 0 5px;
         }
     }
 }

--- a/frontend/TopHitEntries.vue
+++ b/frontend/TopHitEntries.vue
@@ -36,8 +36,9 @@
                         @toggleSpin="$emit('toggleSpin')"
                     />
                 </div>
-                <img v-else-if="thumbnailUrl" :src="thumbnailUrl" class="thumbnail-img" />
+                <img v-else-if="thumbnailUrl" style="display: none" />
                 <v-skeleton-loader height="240" v-else type="image" />
+                <canvas class="thumbnail-img" :id="`${entry.db}-thumbnail-canvas`" v-show="!isActive && thumbnailUrl"></canvas>
             </div>
             <v-card-text>
                 <div class="card-content-entry" data-label="Query TM-score" v-if="entry.qTM">
@@ -143,8 +144,8 @@ export default {
             default: ""
         },
         thumbnailUrl: {
-            type: String,
-            default: null,
+            type: Boolean,
+            default: false,
         },
         isActive: {
             type: Boolean,
@@ -312,7 +313,7 @@ export default {
 
 .thumbnail-img {
     width: 100%;
-    height: auto;
+    height: 240px;
     max-height: 240px;
     object-fit: contain;
     display: block;

--- a/frontend/TopHitEntries.vue
+++ b/frontend/TopHitEntries.vue
@@ -1,0 +1,341 @@
+<template>
+    <v-card 
+    v-if="entry"
+    elevation="2"
+    outlined
+    width="320"
+    max-width="320"
+    min-height="360"
+    class="hit-card"
+    :style="{'--active-color': entry.color}"
+    >
+        <v-tooltip bottom nudge-top="18px" :color="entry.color">
+            <template v-slot:activator="{on}">
+                <v-card-title class="card-title" v-on="on" @click.stop="$emit('jump')">
+                    <span style="font-weight: 700; text-transform: uppercase;" class="card-title-content">{{db}}</span>
+                    <div class="hit-arrow"></div>
+                </v-card-title>
+            </template>
+            <span>Jump to {{ db.toUpperCase() }}</span>
+        </v-tooltip>
+        <template v-if="entry.topHit">
+            <div class="thumbnail-container" style="margin-left: 16px; margin-right: 16px;" @click="$emit('activate')">
+                <div v-if="isActive" ref="viewerSlot" class="viewer-slot">
+                    <StructureViewerToolbar
+                        :isFullscreen="false"
+                        :isSpinning="isSpinning"
+                        :disablePDBButton="true"
+                        :disableImageButton="true"
+                        :disableQueryButton="true"
+                        :disableTargetButton="true"
+                        :disableArrowButton="true"
+                        :disableResetButton="false"
+                        :disableSpinButton="false"
+                        :disableFullscreenButton="true"
+                        @resetView="$emit('resetView')"
+                        @toggleSpin="$emit('toggleSpin')"
+                    />
+                </div>
+                <img v-else-if="thumbnailUrl" :src="thumbnailUrl" class="thumbnail-img" />
+                <v-skeleton-loader height="240" v-else type="image" />
+            </div>
+            <v-card-text>
+                <div class="card-content-entry" data-label="Query TM-score" v-if="entry.qTM">
+                    <span>{{ entry.qTM }}</span>
+                </div>
+                <div class="card-content-entry" data-label="Target TM-score" v-if="entry.tTM">
+                    <span>{{ entry.tTM }}</span>
+                </div>
+                <div class="card-content-entry" :data-label="mode == 1 ? 'Chain Pairing' : 'Target'">
+                    <v-select v-if="mode == 1 && entry.topHit.length > 1"
+                        v-model="selectedObject" :items="entry.topHit"
+                        class="multichain-select"
+                        item-text="title" return-object dense 
+                        :item-color="entry.color"
+                        hide-details
+                        style="font-size: 12px; max-width: 187px;"
+                        flat solo single-line
+                    ></v-select>
+                    <span v-else>
+                        {{ mode == 1 
+                            ? selectedObject.title 
+                            : mode == 2 
+                            ? selectedObject.targetname 
+                            : selectedObject.target }}
+                    </span>
+                </div>
+                <div class="card-content-entry" v-if="entry.hasDescription"
+                data-label="Description"><span>{{ selectedObject.description }}</span></div>
+                <div class="card-content-entry" v-if="entry.hasTaxonomy"
+                data-label="Taxonomy">
+                    <a 
+                    :href="'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=' + selectedObject.taxId" 
+                    target="_blank"
+                    rel="noopener"
+                    :title="selectedObject.taxName"
+                    @click.stop
+                    >{{ selectedObject.taxName }}</a>
+                </div>
+                <template v-if="mode == 2">
+                    <div class="card-content-entry" data-label="IDF-score"><span>{{ selectedObject.idfscore }}</span></div>
+                    <div class="card-content-entry" data-label="RMSD"><span>{{ selectedObject.rmsd }}</span></div>
+                    <div class="card-content-entry" data-label="Node count"><span>{{ selectedObject.nodecount }}</span></div>
+                    <div class="card-content-entry" data-label="Matched residues"><span :title="selectedObject.targetresidues">{{ selectedObject.targetresidues }}</span></div>
+                </template>
+                <template v-else>
+                    <div class="card-content-entry" data-label="Probability"><span>{{ selectedObject.prob }}</span></div>
+                    <div class="card-content-entry" data-label="Sequence Identity"><span>{{ selectedObject.seqId }}</span></div>
+                    <div class="card-content-entry" :data-label="columnName"><span>{{ selectedObject.eval }}</span></div>
+                    <div class="card-content-entry" data-label="Score"><span>{{ selectedObject.score }}</span></div>
+                    <div class="card-content-entry graphical" data-label="Position">
+                        <Ruler
+                            :length="selectedObject.qLen" :start="selectedObject.qStartPos" :end="selectedObject.qEndPos"
+                            :color="selectedObject.color" :label="true"
+                        />
+                    </div>
+                </template>
+            </v-card-text>
+        </template>
+        <template v-else>
+            <v-card-text style="
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 1rem;
+                height: 296px;
+            ">
+            <span
+                style="
+                    transform: translateY(-24px);
+                "
+            >No hit :(</span>
+            </v-card-text>
+        </template>
+    </v-card>
+</template>
+
+<script>
+import Ruler from './Ruler.vue';
+import StructureViewerToolbar from './StructureViewerToolbar.vue';
+
+export default {
+    name: 'TopHitEntries',
+    components: {
+        Ruler,
+        StructureViewerToolbar,
+    },
+    data() {
+        return {
+            selectedObject: null,
+        }
+    },
+    props: {
+        entry: {
+            type: Object,
+            required: true,
+        },
+        mode: {
+            type: Number,
+            default: 0,
+        },
+        columnName: {
+            type: String,
+            default: ""
+        },
+        thumbnailUrl: {
+            type: String,
+            default: null,
+        },
+        isActive: {
+            type: Boolean,
+            default: false,
+        },
+        isSpinning: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    beforeMount() {
+        if (this.entry?.topHit) {
+            this.selectedObject = this.entry.topHit[0]
+        }
+    },
+    computed: {
+        db() {
+            return this.entry?.db.replaceAll(/_folddisco$/g, '')
+        }
+    },
+}
+
+</script>
+
+<style scoped>
+
+.hit-arrow {
+    margin-left: 8px;
+    display: block;
+    background-color: var(--active-color);
+    position: relative;
+    height: 0.6em;
+    width: 4px;
+    opacity: 0;
+    transition: transform 0.4s cubic-bezier(0.075, 0.82, 0.165, 1), opacity 0.4s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+.hit-arrow::before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-left: 0.24em solid white;
+    border-top: 0.3em solid transparent;
+    border-bottom: 0.3em solid transparent;
+    position: absolute;
+    left: 0;
+    z-index: 2;
+    top: 0;
+}
+
+.hit-arrow::after {
+    content: "";
+    width: 0;
+    height: 0;
+    border-left: 0.24em solid var(--active-color);
+    border-top: 0.3em solid transparent;
+    border-bottom: 0.3em solid transparent;
+    position: absolute;
+    right: 0;
+    transform: translateX(100%);
+    z-index: 1;
+    top: 0;
+}
+
+@keyframes wiggle-and-pause {
+    0% { transform: translateX(0); }
+    40% { transform: translateX(0); }
+    45% { transform: translateX(8px); }
+    50% { transform: translateX(0); }
+    55% { transform: translateX(8px); }
+    60% { transform: translateX(0); }
+    100% { transform: translateX(0); }
+}
+        
+/* .hit-arrow:hover {
+    animation: wiggle-and-pause 3.2s infinite;
+} */
+
+.card-title {
+    cursor: pointer;
+}
+
+.card-title-content {
+    position: relative;
+    z-index: 3;
+}
+.card-title-content::before {
+    display: block;
+    content: "";
+    height: 8px;
+    width: 0;
+    background-color: var(--active-color);
+    opacity: 0.7;
+    position: absolute;
+    left: 0;
+    bottom: 6px;
+    z-index: 1;
+    transition: width 0.4s cubic-bezier(0.075, 0.82, 0.165, 1);
+    mix-blend-mode: multiply;
+}
+
+.theme--dark .card-title-content::before {
+    opacity: 0.6;
+    mix-blend-mode: soft-light;
+}
+
+.theme--dark .hit-arrow::before {
+    border-left: 0.24em solid rgb(30, 30, 30);
+}
+
+.card-title:hover .card-title-content::before {
+    width: 100%;
+}
+        
+.card-title:hover .hit-arrow {
+    opacity: 1;
+    animation: wiggle-and-pause 3.2s infinite;
+}
+
+.card-content-entry {
+    display: flex;
+    flex-direction: row;
+    /* font-size: 1rem; */
+    border-bottom: 1px solid #eee;
+    align-items: start;
+
+    &:last-child {
+        border-bottom: 0;
+    }
+}
+
+.card-content-entry::before {
+    content: attr(data-label);
+    font-weight: 600;
+    margin-right: auto;
+    padding-right: 0.5em;
+    word-break: keep-all;
+    flex: 1;
+    white-space: nowrap;
+}
+
+.card-content-entry > span, .card-content-entry > a, .card-content-entry > .content-wrapper {
+    flex: 2;
+    margin-left: auto;
+    text-align: right;
+    word-wrap: anywhere;
+}
+
+.hit-card {
+    transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+.hit-card:hover {
+    box-shadow: 0px 2px 4px -1px rgba(0, 0, 0, 0.2), 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12) !important;
+}
+
+.thumbnail-container {
+    position: relative;
+    width: calc(318px - 32px);
+    min-height: 200px;
+    max-height: 240px;
+    cursor: pointer;
+    overflow: hidden;
+}
+
+.thumbnail-img {
+    width: 100%;
+    height: auto;
+    max-height: 240px;
+    object-fit: contain;
+    display: block;
+    transition: opacity 0.2s ease;
+}
+
+.viewer-slot {
+    width: 100%;
+    height: 240px;
+    position: relative;
+}
+
+
+</style>
+
+<style>
+
+.multichain-select > .v-input__control > .v-input__slot {
+    padding: 0px !important;
+}
+
+.hit-card div.ruler {
+    margin: 10px 0;
+}
+
+</style>

--- a/frontend/TopHits.vue
+++ b/frontend/TopHits.vue
@@ -1,0 +1,214 @@
+<template>
+    <div>
+        <v-sheet class="pa-1 sticky-sheet" :style="{'background-color': $vuetify.theme.dark ? '#1e1e1e' : '#fff'}">
+            <h2 style="margin-top: 0.5em; margin-bottom: 1em;">
+                <div style="display: inline-block; width: 24px;"></div>
+                <span>Top Hits</span>
+            </h2>
+        </v-sheet>
+        <div
+        class="mt-3"
+        style="display: flex;
+               flex-direction: row;
+               flex-wrap: wrap;
+               justify-content: center;
+               align-items: start;
+               gap: 24px 24px;
+               padding-bottom: 32px;
+               ">
+            <template v-if="topHits">
+                <template v-for="(hit, idx) in topHits"
+                >
+                    <TopHitEntries
+                            :entry="hit"
+                            :key="hit.db"
+                            :mode="mode"
+                            :columnName="columnName"
+                            :thumbnailUrl="thumbnailCache[hit.db]"
+                            :isActive="activeCardId === hit.db"
+                            :isSpinning="activeCardId === hit.db && viewerSpinning"
+                            @activate="handleCardActivate(hit)"
+                            @resetView="handleToolbarResetView"
+                            @toggleSpin="handleToolbarToggleSpin"
+                            @jump="$emit('jumpTo', idx)"
+                            />
+                </template>
+            </template>
+        </div>
+        <StructureViewerThumbnail
+            v-if="thumbnailQueue.length > 0"
+            ref="thumbnailViewer"
+            :thumbnailQueue="thumbnailQueue"
+            :hits="hits" :mode="mode"
+            @thumbnail-ready="handleThumbnailReady"
+            @viewer-ready="handleViewerReady"
+        />
+    </div>
+</template>
+
+<script>
+import TopHitEntries from './TopHitEntries.vue';
+import StructureViewerThumbnail from './StructureViewerThumbnail.vue';
+
+export default {
+    name: "TopHits",
+    components: { TopHitEntries, StructureViewerThumbnail },
+    data() {
+        return {
+            topHits: null,
+            columnName: "",
+            thumbnailCache: {},
+            activeCardId: null,
+            thumbnailQueue: [],
+            viewerSpinning: false,
+        }
+    },
+    props: {
+        hits: {
+            type: Object,
+            required: true,
+        },
+        mode: { /* 0: Foldseek; 1: Foldseek Multimer; 2: Folddisco */
+            type: Number,
+            required: true,
+        },
+        alignMode: {
+            type: String,
+            default: "",
+        }
+    },
+    methods: {
+        handleThumbnailReady({ id, blob }) {
+            const url = URL.createObjectURL(blob);
+            this.$set(this.thumbnailCache, id, url);
+        },
+        handleViewerReady() {
+            this.viewerSpinning = true;
+        },
+        handleToolbarResetView() {
+            if (this.$refs.thumbnailViewer) {
+                this.$refs.thumbnailViewer.handleResetView();
+            }
+        },
+        handleToolbarToggleSpin() {
+            if (this.$refs.thumbnailViewer) {
+                this.$refs.thumbnailViewer.handleToggleSpin();
+                this.viewerSpinning = this.$refs.thumbnailViewer.isSpinning;
+            }
+        },
+        handleCardActivate(hit) {
+            if (!hit.topHit) return;
+            const cardId = hit.db;
+
+            if (this.activeCardId === cardId) {
+                // Clicking same card deactivates
+                this.activeCardId = null;
+                this.viewerSpinning = false;
+                this.$nextTick(() => {
+                    if (this.$refs.thumbnailViewer) {
+                        this.$refs.thumbnailViewer.deactivateViewer();
+                    }
+                });
+                return;
+            }
+
+            const wasActive = this.activeCardId !== null;
+            this.activeCardId = cardId;
+
+            this.$nextTick(() => {
+                // Find the TopHitEntries component for this card
+                const entries = this.$children.filter(c => c.$options.name === 'TopHitEntries');
+                const targetEntry = entries.find(c => c.entry.db === cardId);
+                if (!targetEntry || !targetEntry.$refs.viewerSlot) return;
+                const targetEl = targetEntry.$refs.viewerSlot;
+
+                if (this.$refs.thumbnailViewer) {
+                    if (wasActive) {
+                        this.$refs.thumbnailViewer.switchViewer(cardId, hit.topHit, targetEl);
+                    } else {
+                        this.$refs.thumbnailViewer.activateViewer(cardId, hit.topHit, targetEl);
+                    }
+                }
+            });
+        },
+    },
+    beforeMount() {
+        this.topHits = this.hits.results.map(
+            ({alignments, db, color, hasTaxonomy, hasDescription}) => {
+                const minKey = alignments && Object.keys(alignments).length > 0
+                    ? Object.keys(alignments).map(i => Number(i))[0] : -1
+                const firstEntry = minKey < 0 ? null : alignments[minKey]
+                const qTM = this.mode == 1 && minKey >= 0 ? firstEntry[0].complexqtm.toFixed(2) : undefined
+                const tTM = this.mode == 1 && minKey >= 0 ? firstEntry[0].complexttm.toFixed(2) : undefined
+                if (firstEntry && this.mode == 1) {
+                    for (let entry of firstEntry) {
+                        const prefix =
+                            entry.query.lastIndexOf('_') != -1
+                                ? entry.query.substring(entry.query.lastIndexOf('_')+1)
+                                : ''
+                        entry.title = prefix + ' ➔ ' + entry.target
+                    }
+                }
+                return {
+                    db, color, hasDescription, hasTaxonomy, qTM, tTM,
+                    topHit: firstEntry
+                }
+        })
+
+        // Build thumbnail queue from topHits
+        this.thumbnailQueue = this.topHits
+            .filter(hit => hit.topHit && hit.topHit.length > 0)
+            .map(hit => ({
+                id: hit.db,
+                alignments: hit.topHit,
+                db: hit.db,
+            }));
+
+        if (this.alignMode != "") {
+            if (__APP__ == 'foldseek') {
+                switch (this.alignMode) {
+                    case 'tmalign':
+                        this.columnName = 'TM-score'
+                        break;
+                    case 'lolalign':
+                        this.columnName = 'LOL-score'
+                        break;
+                    default:
+                        this.columnName = 'E-Value'
+                }
+            } else {
+                this.columnName = 'E-Value'
+            }
+        }
+    },
+    beforeDestroy() {
+        // Revoke all blob URLs
+        Object.values(this.thumbnailCache).forEach(url => {
+            URL.revokeObjectURL(url);
+        });
+    },
+}
+</script>
+
+<style scoped>
+.sticky-sheet {
+    position: sticky;
+    top: 140px;
+    z-index: 5;
+}
+.sticky-sheet::before {
+    content: "";
+    width: 100%;
+    bottom: 0;
+    left: 0;
+    height: 1px;
+    position: absolute;
+    display: block;
+    z-index: inherit;
+    background-color: rgba(0, 0, 0, 0.12);
+}
+        
+.theme--dark .sticky-sheet::before {
+    background-color: rgba(255, 255, 255, 0.12);
+}
+</style>

--- a/frontend/TopHits.vue
+++ b/frontend/TopHits.vue
@@ -78,9 +78,9 @@ export default {
         }
     },
     methods: {
-        handleThumbnailReady({ id, blob }) {
-            const url = URL.createObjectURL(blob);
-            this.$set(this.thumbnailCache, id, url);
+        handleThumbnailReady({ id, result }) {
+            // const url = URL.createObjectURL(blob);
+            this.$set(this.thumbnailCache, id, result);
         },
         handleViewerReady() {
             this.viewerSpinning = true;

--- a/frontend/Utilities.js
+++ b/frontend/Utilities.js
@@ -1119,3 +1119,21 @@ export function getResnoWithChain(
   }
   return result;
 }
+
+export function wrapLog() {
+  const originalLog = console.log;
+  console.log = function (...args) {
+    if (typeof args[0] === "string" && args[0].includes("STAGE LOG")) {
+      return;
+    }
+    originalLog.apply(console, args);
+  };
+}
+
+export function recoverLog() {
+  const tmpIframe = document.createElement("iframe");
+  tmpIframe.style.display = "none";
+  document.body.appendChild(tmpIframe);
+  console.log = tmpIframe.contentWindow.console.log;
+  document.body.removeChild(tmpIframe);
+}


### PR DESCRIPTION
## Summary
- Batch folddisco queries now return results grouped by `query_index` and `motif` instead of a flat list, so clients can identify which results came from which query/motif pair
- Keeps per-query part files (`alis_{db}_part_{i}`) on disk instead of deleting them after concatenation, enabling `ReadFoldDiscoBatch` to read each query's results individually
- Single-query (non-batch) response format is unchanged for backwards compatibility

## Test plan
- [x] Submitted a batch query (1 structure × 2 motifs) against `h_sapiens_folddisco` locally
- [x] Verified `GET /api/result/folddisco/{ticket}` returns grouped response with correct `query_index` and `motif` per group
- [x] Verified alignments in each group only contain results for that query's motif
- [ ] Verify single-query mode response is unchanged
- [ ] Verify metadata (`meta` field) is correctly filtered per query when `full_header` is enabled on a database

🤖 Generated with [Claude Code](https://claude.com/claude-code)