### PR TITLE
Propagate request trace through logs

### DIFF
--- a/backend/complexsearchjob.go
+++ b/backend/complexsearchjob.go
@@ -48,7 +48,7 @@ func (r ComplexSearchJob) WritePDB(path string) error {
 	return nil
 }
 
-func NewComplexSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, taxfilter string) (JobRequest, error) {
+func NewComplexSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, taxfilter string, otelTrace OtelTraceContext) (JobRequest, error) {
 	job := ComplexSearchJob{
 		max(strings.Count(query, "HEADER"), 1),
 		dbs,
@@ -58,11 +58,12 @@ func NewComplexSearchJobRequest(query string, dbs []string, validDbs []Params, m
 	}
 
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobComplexSearch,
-		job,
-		email,
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobComplexSearch,
+		Job:       job,
+		Email:     email,
+		OtelTrace: otelTrace.Ptr(),
 	}
 
 	ids := make([]string, 0)

--- a/backend/folddiscojob.go
+++ b/backend/folddiscojob.go
@@ -53,7 +53,7 @@ func (r FoldDiscoJob) WritePDB(path string) error {
 	return nil
 }
 
-func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs []Params, resultPath string, email string) (JobRequest, error) {
+func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs []Params, resultPath string, email string, otelTrace OtelTraceContext) (JobRequest, error) {
 	job := FoldDiscoJob{
 		max(strings.Count(query, "HEADER"), 1),
 		dbs,
@@ -64,11 +64,12 @@ func NewFoldDiscoJobRequest(query string, motif string, dbs []string, validDbs [
 	}
 
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobFoldDisco,
-		job,
-		email,
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobFoldDisco,
+		Job:       job,
+		Email:     email,
+		OtelTrace: otelTrace.Ptr(),
 	}
 
 	ids := make([]string, 0)

--- a/backend/foldmasonmsa.go
+++ b/backend/foldmasonmsa.go
@@ -77,17 +77,19 @@ func NewFoldMasonMSAJobRequest(
 	fileNames []string,
 	gapOpen int64,
 	gapExtend int64,
+	otelTrace OtelTraceContext,
 ) (JobRequest, error) {
 	job := FoldMasonMSAJob{
 		queries,
 		fileNames,
 	}
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobFoldMasonMSA,
-		job,
-		"",
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobFoldMasonMSA,
+		Job:       job,
+		Email:     "",
+		OtelTrace: otelTrace.Ptr(),
 	}
 	return request, nil
 }

--- a/backend/indexjob.go
+++ b/backend/indexjob.go
@@ -22,17 +22,18 @@ func (r IndexJob) Rank() float64 {
 	return float64(0)
 }
 
-func NewIndexJobRequest(path string, email string) (JobRequest, error) {
+func NewIndexJobRequest(path string, email string, otelTrace OtelTraceContext) (JobRequest, error) {
 	job := IndexJob{
 		path,
 	}
 
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobIndex,
-		job,
-		email,
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobIndex,
+		Job:       job,
+		Email:     email,
+		OtelTrace: otelTrace.Ptr(),
 	}
 
 	return request, nil

--- a/backend/interfacesearchjob.go
+++ b/backend/interfacesearchjob.go
@@ -48,7 +48,7 @@ func (r InterfaceSearchJob) WritePDB(path string) error {
 	return nil
 }
 
-func NewInterfaceSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, taxfilter string) (JobRequest, error) {
+func NewInterfaceSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, taxfilter string, otelTrace OtelTraceContext) (JobRequest, error) {
 	job := InterfaceSearchJob{
 		max(strings.Count(query, "HEADER"), 1),
 		dbs,
@@ -58,11 +58,12 @@ func NewInterfaceSearchJobRequest(query string, dbs []string, validDbs []Params,
 	}
 
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobInterfaceSearch,
-		job,
-		email,
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobInterfaceSearch,
+		Job:       job,
+		Email:     email,
+		OtelTrace: otelTrace.Ptr(),
 	}
 
 	ids := make([]string, 0)

--- a/backend/jobsystem.go
+++ b/backend/jobsystem.go
@@ -31,11 +31,19 @@ const (
 )
 
 type JobRequest struct {
-	Id     Id          `json:"id" validate:"required"`
-	Status Status      `json:"status" validate:"required"`
-	Type   JobType     `json:"type" validate:"required"`
-	Job    interface{} `json:"job" validate:"required"`
-	Email  string      `json:"email" validate:"omitempty,email"`
+	Id        Id                `json:"id" validate:"required"`
+	Status    Status            `json:"status" validate:"required"`
+	Type      JobType           `json:"type" validate:"required"`
+	Job       interface{}       `json:"job" validate:"required"`
+	Email     string            `json:"email" validate:"omitempty,email"`
+	OtelTrace *OtelTraceContext `json:"otelTrace,omitempty"`
+}
+
+func (r JobRequest) String() string {
+	if r.OtelTrace == nil {
+		return fmt.Sprintf("ticket=%s type=%s status=%s", r.Id, r.Type, r.Status)
+	}
+	return fmt.Sprintf("ticket=%s type=%s status=%s%s", r.Id, r.Type, r.Status, *r.OtelTrace)
 }
 
 type jobRequest JobRequest

--- a/backend/msajob.go
+++ b/backend/msajob.go
@@ -43,7 +43,7 @@ func (r MsaJob) WriteFasta(path string) error {
 	return nil
 }
 
-func NewMsaJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string) (JobRequest, error) {
+func NewMsaJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, otelTrace OtelTraceContext) (JobRequest, error) {
 	job := MsaJob{
 		max(strings.Count(query, ">"), 1),
 		dbs,
@@ -52,11 +52,12 @@ func NewMsaJobRequest(query string, dbs []string, validDbs []Params, mode string
 	}
 
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobMsa,
-		job,
-		email,
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobMsa,
+		Job:       job,
+		Email:     email,
+		OtelTrace: otelTrace.Ptr(),
 	}
 
 	ids := make([]string, len(validDbs))

--- a/backend/pairjob.go
+++ b/backend/pairjob.go
@@ -34,7 +34,7 @@ func (r PairJob) WriteFasta(path string) error {
 	return nil
 }
 
-func NewPairJobRequest(query string, mode string, mail string) (JobRequest, error) {
+func NewPairJobRequest(query string, mode string, mail string, otelTrace OtelTraceContext) (JobRequest, error) {
 	job := PairJob{
 		max(strings.Count(query, ">"), 1),
 		mode,
@@ -42,11 +42,12 @@ func NewPairJobRequest(query string, mode string, mail string) (JobRequest, erro
 	}
 
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobPair,
-		job,
-		mail,
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobPair,
+		Job:       job,
+		Email:     mail,
+		OtelTrace: otelTrace.Ptr(),
 	}
 
 	return request, nil

--- a/backend/searchjob.go
+++ b/backend/searchjob.go
@@ -68,7 +68,7 @@ func isIn(num string, params []string) int {
 
 var validTaxonFilter = regexp.MustCompile(`^[0-9]+(,!?[0-9]+)*$|^$`).MatchString
 
-func NewSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, taxfilter string) (JobRequest, error) {
+func NewSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, taxfilter string, otelTrace OtelTraceContext) (JobRequest, error) {
 	job := SearchJob{
 		max(strings.Count(query, ">"), 1),
 		dbs,
@@ -78,11 +78,12 @@ func NewSearchJobRequest(query string, dbs []string, validDbs []Params, mode str
 	}
 
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobSearch,
-		job,
-		email,
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobSearch,
+		Job:       job,
+		Email:     email,
+		OtelTrace: otelTrace.Ptr(),
 	}
 
 	ids := make([]string, len(validDbs))

--- a/backend/server.go
+++ b/backend/server.go
@@ -38,6 +38,13 @@ func CorsCache(h http.Handler, maxAge int) http.Handler {
 	})
 }
 
+func WithRequestLogContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := ContextWithOtelTrace(req.Context(), CollectRequestTrace(req))
+		next.ServeHTTP(w, req.WithContext(ctx))
+	})
+}
+
 func server(jobsystem JobSystem, config ConfigRoot) {
 	go func() {
 		databases, err := Databases(config.Paths.Databases, false)
@@ -54,7 +61,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 				continue
 			}
 
-			request, err := NewIndexJobRequest(db.Path, "")
+			request, err := NewIndexJobRequest(db.Path, "", OtelTraceContext{Source: "startup-index-bootstrap"})
 			if err != nil {
 				panic(err)
 			}
@@ -62,6 +69,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			_, err = jobsystem.NewJob(request, config.Paths.Results, true)
 			if err != nil {
 				panic(err)
+			}
+			if config.Verbose {
+				log.Printf("ticket created %s", request)
 			}
 		}
 	}()
@@ -74,6 +84,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		r = baseRouter
 	}
 
+	r.Use(WithRequestLogContext)
 	r.Use(Decompress)
 
 	// skip zstd for now since its not supported everywhere (e.g. firefox)
@@ -226,7 +237,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 				return
 			}
 
-			request, err = NewIndexJobRequest(path, req.FormValue("email"))
+			request, err = NewIndexJobRequest(path, req.FormValue("email"), OtelTraceFromContext(req.Context()))
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
@@ -235,6 +246,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
+			}
+			if config.Verbose {
+				log.Printf("ticket created %s", request)
 			}
 
 			err = json.NewEncoder(w).Encode(result)
@@ -325,19 +339,19 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 
 		var request JobRequest
 		if config.App == AppMMseqs2 {
-			request, err = NewSearchJobRequest(query, dbs, databases, mode, config.Paths.Results, email, taxfilter)
+			request, err = NewSearchJobRequest(query, dbs, databases, mode, config.Paths.Results, email, taxfilter, OtelTraceFromContext(req.Context()))
 		} else if config.App == AppFoldseek {
 			modes := strings.Split(mode, "-")
 			interfaceIdx := isIn("interface", modes)
 			modeIdx := isIn("complex", modes)
 			if interfaceIdx != -1 {
 				modeWithoutInterface := strings.Join(append(modes[:interfaceIdx], modes[interfaceIdx+1:]...), "-")
-				request, err = NewInterfaceSearchJobRequest(query, dbs, databases, modeWithoutInterface, config.Paths.Results, email, taxfilter)
+				request, err = NewInterfaceSearchJobRequest(query, dbs, databases, modeWithoutInterface, config.Paths.Results, email, taxfilter, OtelTraceFromContext(req.Context()))
 			} else if modeIdx != -1 {
 				modeWithoutComplex := strings.Join(append(modes[:modeIdx], modes[modeIdx+1:]...), "-")
-				request, err = NewComplexSearchJobRequest(query, dbs, databases, modeWithoutComplex, config.Paths.Results, email, taxfilter)
+				request, err = NewComplexSearchJobRequest(query, dbs, databases, modeWithoutComplex, config.Paths.Results, email, taxfilter, OtelTraceFromContext(req.Context()))
 			} else {
-				request, err = NewStructureSearchJobRequest(query, dbs, databases, mode, config.Paths.Results, email, iterativesearch, taxfilter)
+				request, err = NewStructureSearchJobRequest(query, dbs, databases, mode, config.Paths.Results, email, iterativesearch, taxfilter, OtelTraceFromContext(req.Context()))
 			}
 		} else {
 			http.Error(w, "Job type not supported by this server", http.StatusBadRequest)
@@ -351,6 +365,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
+		}
+		if config.Verbose {
+			log.Printf("ticket created %s", request)
 		}
 
 		err = json.NewEncoder(w).Encode(result)
@@ -406,7 +423,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			return
 		}
 
-		request, err = NewMsaJobRequest(query, dbs, databases, mode, config.Paths.Results, email)
+		request, err = NewMsaJobRequest(query, dbs, databases, mode, config.Paths.Results, email, OtelTraceFromContext(req.Context()))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -415,6 +432,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
+		}
+		if config.Verbose {
+			log.Printf("ticket created %s", request)
 		}
 
 		err = json.NewEncoder(w).Encode(result)
@@ -461,7 +481,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			email = req.FormValue("email")
 		}
 
-		request, err := NewPairJobRequest(query, mode, email)
+		request, err := NewPairJobRequest(query, mode, email, OtelTraceFromContext(req.Context()))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -470,6 +490,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
+		}
+		if config.Verbose {
+			log.Printf("ticket created %s", request)
 		}
 
 		err = json.NewEncoder(w).Encode(result)
@@ -523,7 +546,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		}
 		fileNames = req.Form["fileNames[]"]
 
-		request, err := NewFoldMasonMSAJobRequest(queries, fileNames, gapOpen, gapExtend)
+		request, err := NewFoldMasonMSAJobRequest(queries, fileNames, gapOpen, gapExtend, OtelTraceFromContext(req.Context()))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -532,6 +555,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
+		}
+		if config.Verbose {
+			log.Printf("ticket created %s", request)
 		}
 		err = json.NewEncoder(w).Encode(result)
 		if err != nil {
@@ -591,7 +617,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 			return
 		}
 
-		request, err := NewFoldDiscoJobRequest(query, motif, dbs, databases /*mode,*/, config.Paths.Results, email /*, taxfilter*/)
+		request, err := NewFoldDiscoJobRequest(query, motif, dbs, databases /*mode,*/, config.Paths.Results, email /*, taxfilter*/, OtelTraceFromContext(req.Context()))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -600,6 +626,9 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
+		}
+		if config.Verbose {
+			log.Printf("ticket created %s", request)
 		}
 
 		err = json.NewEncoder(w).Encode(result)
@@ -908,6 +937,7 @@ func server(jobsystem JobSystem, config ConfigRoot) {
 				db_prefix := strings.TrimSuffix(database, "_folddisco")
 				db_foldcomp := db_prefix + "_foldcomp"
 				err = execCommandSync(
+					req.Context(),
 					config.Verbose,
 					[]string{
 						config.Paths.FoldComp,

--- a/backend/structuresearchjob.go
+++ b/backend/structuresearchjob.go
@@ -56,7 +56,7 @@ func (r StructureSearchJob) WritePDB(path string) error {
 	return nil
 }
 
-func NewStructureSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, iterativeSearch bool, taxfilter string) (JobRequest, error) {
+func NewStructureSearchJobRequest(query string, dbs []string, validDbs []Params, mode string, resultPath string, email string, iterativeSearch bool, taxfilter string, otelTrace OtelTraceContext) (JobRequest, error) {
 	job := StructureSearchJob{
 		max(strings.Count(query, "HEADER"), 1),
 		dbs,
@@ -67,11 +67,12 @@ func NewStructureSearchJobRequest(query string, dbs []string, validDbs []Params,
 	}
 
 	request := JobRequest{
-		job.Hash(),
-		StatusPending,
-		JobStructureSearch,
-		job,
-		email,
+		Id:        job.Hash(),
+		Status:    StatusPending,
+		Type:      JobStructureSearch,
+		Job:       job,
+		Email:     email,
+		OtelTrace: otelTrace.Ptr(),
 	}
 
 	ids := make([]string, len(validDbs))

--- a/backend/trace.go
+++ b/backend/trace.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type OtelTraceContext struct {
+	Source      string `json:"source,omitempty"`
+	Traceparent string `json:"traceparent,omitempty"`
+	Tracestate  string `json:"tracestate,omitempty"`
+	RequestID   string `json:"x_request_id,omitempty"`
+}
+
+func (t OtelTraceContext) Empty() bool {
+	return t.Source == "" && t.Traceparent == "" && t.Tracestate == "" && t.RequestID == ""
+}
+
+func (t OtelTraceContext) String() string {
+	var builder strings.Builder
+	traceID, spanID := parseTraceparent(t.Traceparent)
+
+	if t.Source != "" {
+		builder.WriteString(" source=")
+		builder.WriteString(strconv.Quote(t.Source))
+	}
+	if t.Traceparent != "" {
+		builder.WriteString(" traceparent=")
+		builder.WriteString(strconv.Quote(t.Traceparent))
+	}
+	if t.Tracestate != "" {
+		builder.WriteString(" tracestate=")
+		builder.WriteString(strconv.Quote(t.Tracestate))
+	}
+	if t.RequestID != "" {
+		builder.WriteString(" x_request_id=")
+		builder.WriteString(strconv.Quote(t.RequestID))
+	}
+	if traceID != "" {
+		builder.WriteString(" trace_id=")
+		builder.WriteString(strconv.Quote(traceID))
+	}
+	if spanID != "" {
+		builder.WriteString(" span_id=")
+		builder.WriteString(strconv.Quote(spanID))
+	}
+
+	return builder.String()
+}
+
+func (t OtelTraceContext) Ptr() *OtelTraceContext {
+	if t.Empty() {
+		return nil
+	}
+	trace := t
+	return &trace
+}
+
+type otelTraceContextKey struct{}
+
+func ContextWithOtelTrace(ctx context.Context, trace OtelTraceContext) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if trace.Empty() {
+		return ctx
+	}
+	return context.WithValue(ctx, otelTraceContextKey{}, trace)
+}
+
+func OtelTraceFromContext(ctx context.Context) OtelTraceContext {
+	if ctx == nil {
+		return OtelTraceContext{}
+	}
+	if trace, ok := ctx.Value(otelTraceContextKey{}).(OtelTraceContext); ok {
+		return trace
+	}
+	return OtelTraceContext{}
+}
+
+func TraceStr(ctx context.Context) string {
+	return OtelTraceFromContext(ctx).String()
+}
+
+func CollectRequestTrace(req *http.Request) OtelTraceContext {
+	source := req.Method
+	if req.URL != nil && req.URL.Path != "" {
+		source += " " + req.URL.Path
+	}
+
+	return OtelTraceContext{
+		Source:      source,
+		Traceparent: strings.TrimSpace(req.Header.Get("traceparent")),
+		Tracestate:  strings.TrimSpace(req.Header.Get("tracestate")),
+		RequestID:   strings.TrimSpace(req.Header.Get("X-Request-Id")),
+	}
+}
+
+func parseTraceparent(traceparent string) (string, string) {
+	parts := strings.Split(strings.TrimSpace(traceparent), "-")
+	if len(parts) != 4 {
+		return "", ""
+	}
+
+	traceID := strings.TrimSpace(parts[1])
+	spanID := strings.TrimSpace(parts[2])
+	if len(traceID) != 32 || len(spanID) != 16 {
+		return "", ""
+	}
+
+	return traceID, spanID
+}

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -70,7 +71,7 @@ func gpuParameters(config *GpuConfig) ([]string, []string) {
 	return parameters, environ
 }
 
-func execCommand(verbose bool, parameters []string, environ []string) (*exec.Cmd, chan error, error) {
+func execCommand(ctx context.Context, verbose bool, parameters []string, environ []string) (*exec.Cmd, chan error, error) {
 	cmd := exec.Command(
 		parameters[0],
 		parameters[1:]...,
@@ -112,15 +113,15 @@ func execCommand(verbose bool, parameters []string, environ []string) (*exec.Cmd
 
 const maxDuration time.Duration = 1<<63 - 1
 
-func execCommandSync(verbose bool, parameters []string, environ []string, timeout time.Duration) error {
-	cmd, done, err := execCommand(verbose, parameters, environ)
+func execCommandSync(ctx context.Context, verbose bool, parameters []string, environ []string, timeout time.Duration) error {
+	cmd, done, err := execCommand(ctx, verbose, parameters, environ)
 	if err != nil {
 		return err
 	}
 	select {
 	case <-time.After(timeout):
 		if err := KillCommand(cmd); err != nil {
-			log.Printf("Failed to kill: %s\n", err)
+			log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 		}
 		return &JobTimeoutError{}
 	case err := <-done:
@@ -162,7 +163,7 @@ func ismmCIFFile(filePath string) (bool, error) {
 	return false, nil
 }
 
-func RunJob(request JobRequest, config ConfigRoot) (err error) {
+func RunJob(ctx context.Context, request JobRequest, config ConfigRoot) (err error) {
 	start := time.Now()
 	switch job := request.Job.(type) {
 	case SearchJob:
@@ -228,7 +229,7 @@ func RunJob(request JobRequest, config ConfigRoot) (err error) {
 				gpupar, environ := gpuParameters(params.GpuConfig)
 				parameters = append(parameters, gpupar...)
 
-				cmd, done, err := execCommand(config.Verbose, parameters, environ)
+				cmd, done, err := execCommand(ctx, config.Verbose, parameters, environ)
 				if err != nil {
 					errChan <- &JobExecutionError{err}
 					return
@@ -237,7 +238,7 @@ func RunJob(request JobRequest, config ConfigRoot) (err error) {
 				select {
 				case <-time.After(1 * time.Hour):
 					if err := KillCommand(cmd); err != nil {
-						log.Printf("Failed to kill: %s\n", err)
+						log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 					}
 					errChan <- &JobTimeoutError{}
 				case err := <-done:
@@ -260,6 +261,7 @@ func RunJob(request JobRequest, config ConfigRoot) (err error) {
 		}
 
 		err = execCommandSync(
+			ctx,
 			config.Verbose,
 			[]string{
 				config.Paths.Mmseqs,
@@ -274,6 +276,7 @@ func RunJob(request JobRequest, config ConfigRoot) (err error) {
 			return &JobExecutionError{err}
 		}
 		err = execCommandSync(
+			ctx,
 			config.Verbose,
 			[]string{
 				config.Paths.Mmseqs,
@@ -310,7 +313,7 @@ func RunJob(request JobRequest, config ConfigRoot) (err error) {
 		}
 
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		return nil
 	case StructureSearchJob:
@@ -364,6 +367,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 				resultBase,
 			}
 			err = execCommandSync(
+				ctx,
 				config.Verbose,
 				parameters,
 				[]string{},
@@ -496,7 +500,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 				gpupar, environ := gpuParameters(params.GpuConfig)
 				parameters = append(parameters, gpupar...)
 
-				cmd, done, err := execCommand(config.Verbose, parameters, environ)
+				cmd, done, err := execCommand(ctx, config.Verbose, parameters, environ)
 				if err != nil {
 					errChan <- &JobExecutionError{err}
 					return
@@ -505,7 +509,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 				select {
 				case <-time.After(1 * time.Hour):
 					if err := KillCommand(cmd); err != nil {
-						log.Printf("Failed to kill: %s\n", err)
+						log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 					}
 					errChan <- &JobTimeoutError{}
 				case err := <-done:
@@ -529,6 +533,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 
 		if !is3Di {
 			err = execCommandSync(
+				ctx,
 				config.Verbose,
 				[]string{
 					config.Paths.Foldseek,
@@ -543,6 +548,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 				return &JobExecutionError{err}
 			}
 			err = execCommandSync(
+				ctx,
 				config.Verbose,
 				[]string{
 					config.Paths.Foldseek,
@@ -580,7 +586,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 		}
 
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		return nil
 	case ComplexSearchJob:
@@ -686,7 +692,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 					parameters = append(parameters, job.TaxFilter)
 				}
 
-				cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+				cmd, done, err := execCommand(ctx, config.Verbose, parameters, []string{})
 				if err != nil {
 					errChan <- &JobExecutionError{err}
 					return
@@ -695,7 +701,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 				select {
 				case <-time.After(1 * time.Hour):
 					if err := KillCommand(cmd); err != nil {
-						log.Printf("Failed to kill: %s\n", err)
+						log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 					}
 					errChan <- &JobTimeoutError{}
 				case err := <-done:
@@ -718,6 +724,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 		}
 
 		err = execCommandSync(
+			ctx,
 			config.Verbose,
 			[]string{
 				config.Paths.Foldseek,
@@ -732,6 +739,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 			return &JobExecutionError{err}
 		}
 		err = execCommandSync(
+			ctx,
 			config.Verbose,
 			[]string{
 				config.Paths.Foldseek,
@@ -768,7 +776,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 		}
 
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		return nil
 	case InterfaceSearchJob:
@@ -869,7 +877,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 					parameters = append(parameters, job.TaxFilter)
 				}
 
-				cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+				cmd, done, err := execCommand(ctx, config.Verbose, parameters, []string{})
 				if err != nil {
 					errChan <- &JobExecutionError{err}
 					return
@@ -878,7 +886,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 				select {
 				case <-time.After(1 * time.Hour):
 					if err := KillCommand(cmd); err != nil {
-						log.Printf("Failed to kill: %s\n", err)
+						log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 					}
 					errChan <- &JobTimeoutError{}
 				case err := <-done:
@@ -901,6 +909,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 		}
 
 		err = execCommandSync(
+			ctx,
 			config.Verbose,
 			[]string{
 				config.Paths.Foldseek,
@@ -915,6 +924,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 			return &JobExecutionError{err}
 		}
 		err = execCommandSync(
+			ctx,
 			config.Verbose,
 			[]string{
 				config.Paths.Foldseek,
@@ -929,6 +939,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 			return &JobExecutionError{err}
 		}
 		err = execCommandSync(
+			ctx,
 			config.Verbose,
 			[]string{
 				"mv",
@@ -964,7 +975,7 @@ mv -f -- "${BASE}/query.lookup_tmp" "${BASE}/query.lookup"
 		}
 
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		return nil
 	case MsaJob:
@@ -1211,7 +1222,7 @@ rm -rf -- "${BASE}/tmp1" "${BASE}/tmp2" "${BASE}/tmp3"
 			}
 		}
 
-		cmd, done, err := execCommand(config.Verbose, parameters, environ)
+		cmd, done, err := execCommand(ctx, config.Verbose, parameters, environ)
 		if err != nil {
 			return &JobExecutionError{err}
 		}
@@ -1219,7 +1230,7 @@ rm -rf -- "${BASE}/tmp1" "${BASE}/tmp2" "${BASE}/tmp3"
 		select {
 		case <-time.After(1 * time.Hour):
 			if err := KillCommand(cmd); err != nil {
-				log.Printf("Failed to kill: %s\n", err)
+				log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 			}
 			return &JobTimeoutError{}
 		case err := <-done:
@@ -1334,7 +1345,7 @@ rm -rf -- "${BASE}/tmp1" "${BASE}/tmp2" "${BASE}/tmp3"
 		}
 
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		return nil
 	case PairJob:
@@ -1528,7 +1539,7 @@ rm -rf -- "${BASE}/tmp"
 			}
 		}
 
-		cmd, done, err := execCommand(config.Verbose, parameters, environ)
+		cmd, done, err := execCommand(ctx, config.Verbose, parameters, environ)
 		if err != nil {
 			return &JobExecutionError{err}
 		}
@@ -1536,7 +1547,7 @@ rm -rf -- "${BASE}/tmp"
 		select {
 		case <-time.After(1 * time.Hour):
 			if err := KillCommand(cmd); err != nil {
-				log.Printf("Failed to kill: %s\n", err)
+				log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 			}
 			return &JobTimeoutError{}
 		case err := <-done:
@@ -1596,7 +1607,7 @@ rm -rf -- "${BASE}/tmp"
 			}
 		}
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		return nil
 	case IndexJob:
@@ -1617,7 +1628,7 @@ rm -rf -- "${BASE}/tmp"
 			return &JobExecutionError{err}
 		}
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		params.Status = StatusComplete
 		err = SaveParams(file+".params", params)
@@ -1638,14 +1649,14 @@ rm -rf -- "${BASE}/tmp"
 			"--report-paths",
 			"0",
 		}
-		cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+		cmd, done, err := execCommand(ctx, config.Verbose, parameters, []string{})
 		if err != nil {
 			return &JobExecutionError{err}
 		}
 		select {
 		case <-time.After(1 * time.Hour):
 			if err := KillCommand(cmd); err != nil {
-				log.Printf("Failed to kill: %s\n", err)
+				log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 			}
 			return &JobTimeoutError{}
 		case err := <-done:
@@ -1654,11 +1665,11 @@ rm -rf -- "${BASE}/tmp"
 			}
 		}
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		return nil
 	case FoldDiscoJob:
-		log.Print(config.Paths.FoldDisco)
+		log.Print(config.Paths.FoldDisco, TraceStr(ctx))
 		resultBase := filepath.Join(config.Paths.Results, string(request.Id))
 		var wg sync.WaitGroup
 		errChan := make(chan error, len(job.Database))
@@ -1706,12 +1717,12 @@ rm -rf -- "${BASE}/tmp"
 						if len(arr) == 2 {
 							threads, err = strconv.Atoi(arr[1])
 							if err != nil {
-								log.Printf("Failed to parse MMSEQS_NUM_THREADS: %s\n", arr[1])
+								log.Printf("Failed to parse MMSEQS_NUM_THREADS: %s%s\n", arr[1], TraceStr(ctx))
 								errChan <- &JobExecutionError{err}
 								return
 							}
 						} else {
-							log.Printf("Invalid MMSEQS_NUM_THREADS environment variable: %s\n", kv)
+							log.Printf("Invalid MMSEQS_NUM_THREADS environment variable: %s%s\n", kv, TraceStr(ctx))
 							errChan <- &JobExecutionError{errors.New("invalid MMSEQS_NUM_THREADS environment variable")}
 							return
 						}
@@ -1742,7 +1753,7 @@ rm -rf -- "${BASE}/tmp"
 				}
 				parameters = append(parameters, strings.Fields(params.Search)...)
 
-				cmd, done, err := execCommand(config.Verbose, parameters, []string{})
+				cmd, done, err := execCommand(ctx, config.Verbose, parameters, []string{})
 				if err != nil {
 					errChan <- &JobExecutionError{err}
 					return
@@ -1751,7 +1762,7 @@ rm -rf -- "${BASE}/tmp"
 				select {
 				case <-time.After(1 * time.Hour):
 					if err := KillCommand(cmd); err != nil {
-						log.Printf("Failed to kill: %s\n", err)
+						log.Printf("Failed to kill: %s%s\n", err, TraceStr(ctx))
 					}
 					errChan <- &JobTimeoutError{}
 				case err := <-done:
@@ -1784,6 +1795,7 @@ printf("%c%c%c%c",5,0,0,0) > db".dbtype"; printf("%c%c%c%c",0,0,0,0) > db"_seq.d
 									filepath.Join(resultBase, "alis_"+database),
 								}
 								err = execCommandSync(
+									ctx,
 									config.Verbose,
 									parameters,
 									[]string{},
@@ -1794,6 +1806,7 @@ printf("%c%c%c%c",5,0,0,0) > db".dbtype"; printf("%c%c%c%c",0,0,0,0) > db"_seq.d
 									return
 								}
 								err = execCommandSync(
+									ctx,
 									config.Verbose,
 									[]string{
 										config.Paths.Foldseek,
@@ -1818,6 +1831,7 @@ printf("%c%c%c%c",5,0,0,0) > db".dbtype"; printf("%c%c%c%c",0,0,0,0) > db"_seq.d
 								}
 								if params.Taxonomy {
 									err = execCommandSync(
+										ctx,
 										config.Verbose,
 										[]string{
 											config.Paths.Foldseek,
@@ -1870,7 +1884,7 @@ printf("%c%c%c%c",5,0,0,0) > db".dbtype"; printf("%c%c%c%c",0,0,0,0) > db"_seq.d
 		}
 
 		if config.Verbose {
-			log.Printf("Process finished gracefully without error in %s\n", time.Since(start))
+			log.Printf("Process finished gracefully without error in %s%s\n", time.Since(start), TraceStr(ctx))
 		}
 		return nil
 	default:
@@ -1880,6 +1894,7 @@ printf("%c%c%c%c",5,0,0,0) > db".dbtype"; printf("%c%c%c%c",0,0,0,0) > db"_seq.d
 
 func worker(jobsystem JobSystem, config ConfigRoot) {
 	log.Println("MMseqs2 worker")
+	startupCtx := context.Background()
 	mailer := MailTransport(NullTransport{})
 	if config.Mail.Mailer != nil {
 		log.Println("Using " + config.Mail.Mailer.Type + " mail transport")
@@ -1959,6 +1974,7 @@ func worker(jobsystem JobSystem, config ConfigRoot) {
 						}
 						_, environ := gpuParameters(p.GpuConfig)
 						execCommandSync(
+							startupCtx,
 							config.Verbose,
 							parameters,
 							environ,
@@ -1996,6 +2012,7 @@ func worker(jobsystem JobSystem, config ConfigRoot) {
 					}
 				}
 				execCommandSync(
+					startupCtx,
 					config.Verbose,
 					parameters,
 					environ,
@@ -2049,17 +2066,22 @@ func worker(jobsystem JobSystem, config ConfigRoot) {
 			continue
 		}
 
+		jobCtx := context.Background()
+		if job.OtelTrace != nil {
+			jobCtx = ContextWithOtelTrace(jobCtx, *job.OtelTrace)
+		}
+
 		jobsystem.SetStatus(ticket.Id, StatusRunning)
-		err = RunJob(job, config)
+		err = RunJob(jobCtx, job, config)
 		mailTemplate := config.Mail.Templates.Success
 		switch err.(type) {
 		case *JobExecutionError, *JobInvalidError:
 			jobsystem.SetStatus(ticket.Id, StatusError)
-			log.Print(err)
+			log.Print(err, TraceStr(jobCtx))
 			mailTemplate = config.Mail.Templates.Error
 		case *JobTimeoutError:
 			jobsystem.SetStatus(ticket.Id, StatusError)
-			log.Print(err)
+			log.Print(err, TraceStr(jobCtx))
 			mailTemplate = config.Mail.Templates.Timeout
 		case nil:
 			jobsystem.SetStatus(ticket.Id, StatusComplete)
@@ -2072,7 +2094,7 @@ func worker(jobsystem JobSystem, config ConfigRoot) {
 				fmt.Sprintf(mailTemplate.Body, string(ticket.Id)),
 			})
 			if err != nil {
-				log.Print(err)
+				log.Print(err, TraceStr(jobCtx))
 			}
 		}
 	}


### PR DESCRIPTION
## Problem
MMseqs2-App server does not allow to correlate logs with request ids.

## Solution
Add an OTEL trace context payload to `JobRequest`, populate it once from HTTP middleware, and pass it through the job constructors so the same context is available when the worker executes the job. Update job-scoped worker logs to append that context, and include explicit `trace_id` and `span_id` fields derived from `traceparent` for easier downstream parsing.
